### PR TITLE
Curl adapter creates duplicate requests

### DIFF
--- a/src/CrowdinApiClient/Http/Client/CurlHttpClient.php
+++ b/src/CrowdinApiClient/Http/Client/CurlHttpClient.php
@@ -99,7 +99,7 @@ class CurlHttpClient implements CrowdinHttpClientInterface
             throw new HttpException($errStr . '(cURL Error: ' . $errNo . ')', $responseCode);
         }
 
-        $this->curlExec($ch);
+        $this->curlClose($ch);
 
         return $response;
     }


### PR DESCRIPTION
If curl adapter is set the api is called twice and if need to create a new object via the api it causes creating duplicated objects.