### PR TITLE
Allow guzzle 7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     "require": {
         "php": ">=7.1",
         "ext-json": "*",
-        "guzzlehttp/guzzle": "^6.2"
+        "guzzlehttp/guzzle": "^6.2 || ^7"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^2.15",


### PR DESCRIPTION
I am using some libraries that require guzzle http 7, and composer is blocking me from installing this. 

With this change, i can use this package.
