### PR TITLE
remove eta from reports, imports and exports

### DIFF
--- a/src/CrowdinApiClient/Model/GlossaryExport.php
+++ b/src/CrowdinApiClient/Model/GlossaryExport.php
@@ -48,11 +48,6 @@ class GlossaryExport extends BaseModel
      */
     protected $finishedAt;
 
-    /**
-     * @var string
-     */
-    protected $eta;
-
     public function __construct(array $data = [])
     {
         parent::__construct($data);
@@ -65,7 +60,6 @@ class GlossaryExport extends BaseModel
         $this->updatedAt = (string)$this->getDataProperty('updatedAt');
         $this->startedAt = (string)$this->getDataProperty('startedAt');
         $this->finishedAt = (string)$this->getDataProperty('finishedAt');
-        $this->eta = (string)$this->getDataProperty('eta');
     }
 
     /**
@@ -194,21 +188,5 @@ class GlossaryExport extends BaseModel
     public function setFinishedAt(string $finishedAt): void
     {
         $this->finishedAt = $finishedAt;
-    }
-
-    /**
-     * @return string
-     */
-    public function getEta(): string
-    {
-        return $this->eta;
-    }
-
-    /**
-     * @param string $eta
-     */
-    public function setEta(string $eta): void
-    {
-        $this->eta = $eta;
     }
 }

--- a/src/CrowdinApiClient/Model/GlossaryImport.php
+++ b/src/CrowdinApiClient/Model/GlossaryImport.php
@@ -48,11 +48,6 @@ class GlossaryImport extends BaseModel
      */
     protected $finishedAt;
 
-    /**
-     * @var string
-     */
-    protected $eta;
-
     public function __construct(array $data = [])
     {
         parent::__construct($data);
@@ -65,7 +60,6 @@ class GlossaryImport extends BaseModel
         $this->updatedAt = (string)$this->getDataProperty('updatedAt');
         $this->startedAt = (string)$this->getDataProperty('startedAt');
         $this->finishedAt = (string)$this->getDataProperty('finishedAt');
-        $this->eta = (string)$this->getDataProperty('eta');
     }
 
     /**
@@ -130,13 +124,5 @@ class GlossaryImport extends BaseModel
     public function getFinishedAt(): string
     {
         return $this->finishedAt;
-    }
-
-    /**
-     * @return string
-     */
-    public function getEta(): string
-    {
-        return $this->eta;
     }
 }

--- a/src/CrowdinApiClient/Model/PreTranslation.php
+++ b/src/CrowdinApiClient/Model/PreTranslation.php
@@ -49,11 +49,6 @@ class PreTranslation extends BaseModel
     protected $finishedAt;
 
     /**
-     * @var string
-     */
-    protected $eta;
-
-    /**
      * PreTranslation constructor.
      * @param array $data
      */
@@ -68,7 +63,6 @@ class PreTranslation extends BaseModel
         $this->updatedAt = (string)$this->getDataProperty('updatedAt');
         $this->startedAt = (string)$this->getDataProperty('startedAt');
         $this->finishedAt = (string)$this->getDataProperty('finishedAt');
-        $this->eta = (string)$this->getDataProperty('eta');
     }
 
     /**
@@ -197,21 +191,5 @@ class PreTranslation extends BaseModel
     public function setFinishedAt(string $finishedAt): void
     {
         $this->finishedAt = $finishedAt;
-    }
-
-    /**
-     * @return string
-     */
-    public function getEta(): string
-    {
-        return $this->eta;
-    }
-
-    /**
-     * @param string $eta
-     */
-    public function setEta(string $eta): void
-    {
-        $this->eta = $eta;
     }
 }

--- a/src/CrowdinApiClient/Model/Report.php
+++ b/src/CrowdinApiClient/Model/Report.php
@@ -48,11 +48,6 @@ class Report extends BaseModel
      */
     protected $finishedAt;
 
-    /**
-     * @var string
-     */
-    protected $eta;
-
     public function __construct(array $data = [])
     {
         parent::__construct($data);
@@ -64,7 +59,6 @@ class Report extends BaseModel
         $this->updatedAt = (string)$this->getDataProperty('updatedAt');
         $this->startedAt = (string)$this->getDataProperty('startedAt');
         $this->finishedAt = (string)$this->getDataProperty('finishedAt');
-        $this->eta = (string)$this->getDataProperty('eta');
     }
 
     /**
@@ -193,21 +187,5 @@ class Report extends BaseModel
     public function setFinishedAt(string $finishedAt): void
     {
         $this->finishedAt = $finishedAt;
-    }
-
-    /**
-     * @return string
-     */
-    public function getEta(): string
-    {
-        return $this->eta;
-    }
-
-    /**
-     * @param string $eta
-     */
-    public function setEta(string $eta): void
-    {
-        $this->eta = $eta;
     }
 }

--- a/src/CrowdinApiClient/Model/TranslationMemoryExport.php
+++ b/src/CrowdinApiClient/Model/TranslationMemoryExport.php
@@ -48,11 +48,6 @@ class TranslationMemoryExport extends BaseModel
      */
     protected $finishedAt;
 
-    /**
-     * @var string
-     */
-    protected $eta;
-
     public function __construct(array $data = [])
     {
         parent::__construct($data);
@@ -64,7 +59,6 @@ class TranslationMemoryExport extends BaseModel
         $this->updatedAt = (string)$this->getDataProperty('updatedAt');
         $this->startedAt = (string)$this->getDataProperty('startedAt');
         $this->finishedAt = (string)$this->getDataProperty('finishedAt');
-        $this->eta = (string)$this->getDataProperty('eta');
     }
 
     /**
@@ -193,21 +187,5 @@ class TranslationMemoryExport extends BaseModel
     public function setFinishedAt(string $finishedAt): void
     {
         $this->finishedAt = $finishedAt;
-    }
-
-    /**
-     * @return string
-     */
-    public function getEta(): string
-    {
-        return $this->eta;
-    }
-
-    /**
-     * @param string $eta
-     */
-    public function setEta(string $eta): void
-    {
-        $this->eta = $eta;
     }
 }

--- a/src/CrowdinApiClient/Model/TranslationMemoryImport.php
+++ b/src/CrowdinApiClient/Model/TranslationMemoryImport.php
@@ -48,11 +48,6 @@ class TranslationMemoryImport extends BaseModel
      */
     protected $finishedAt;
 
-    /**
-     * @var string
-     */
-    protected $eta;
-
     public function __construct(array $data = [])
     {
         parent::__construct($data);
@@ -64,7 +59,6 @@ class TranslationMemoryImport extends BaseModel
         $this->updatedAt = (string)$this->getDataProperty('updatedAt');
         $this->startedAt = (string)$this->getDataProperty('startedAt');
         $this->finishedAt = (string)$this->getDataProperty('finishedAt');
-        $this->eta = (string)$this->getDataProperty('eta');
     }
 
     /**
@@ -193,21 +187,5 @@ class TranslationMemoryImport extends BaseModel
     public function setFinishedAt(string $finishedAt): void
     {
         $this->finishedAt = $finishedAt;
-    }
-
-    /**
-     * @return string
-     */
-    public function getEta(): string
-    {
-        return $this->eta;
-    }
-
-    /**
-     * @param string $eta
-     */
-    public function setEta(string $eta): void
-    {
-        $this->eta = $eta;
     }
 }

--- a/tests/CrowdinApiClient/Api/Enterprise/GlossaryApiTest.php
+++ b/tests/CrowdinApiClient/Api/Enterprise/GlossaryApiTest.php
@@ -159,8 +159,7 @@ class GlossaryApiTest extends AbstractTestApi
                     "createdAt": "2019-09-23T07:06:43+00:00",
                     "updatedAt": "2019-09-23T07:06:43+00:00",
                     "startedAt": "2019-11-13T08:17:23Z",
-                    "finishedAt": "2019-11-13T08:17:23Z",
-                    "eta": "1 second"
+                    "finishedAt": "2019-11-13T08:17:23Z"
                   }
                 }'
         ]);

--- a/tests/CrowdinApiClient/Api/Enterprise/ReportApiTest.php
+++ b/tests/CrowdinApiClient/Api/Enterprise/ReportApiTest.php
@@ -26,8 +26,7 @@ class ReportApiTest extends AbstractTestApi
                   "createdAt": "2019-09-23T11:26:54+00:00",
                   "updatedAt": "2019-09-23T11:26:54+00:00",
                   "startedAt": "2019-09-23T11:26:54+00:00",
-                  "finishedAt": "2019-09-23T11:26:54+00:00",
-                  "eta": "1 second"
+                  "finishedAt": "2019-09-23T11:26:54+00:00"
                 }'
         ]);
 
@@ -71,8 +70,7 @@ class ReportApiTest extends AbstractTestApi
               "createdAt": "2019-09-23T11:26:54+00:00",
               "updatedAt": "2019-09-23T11:26:54+00:00",
               "startedAt": "2019-09-23T11:26:54+00:00",
-              "finishedAt": "2019-09-23T11:26:54+00:00",
-              "eta": "1 second"
+              "finishedAt": "2019-09-23T11:26:54+00:00"
             }');
 
         $report = $this->crowdin->report->get(124, '50fb3506-4127-4ba8-8296-f97dc7e3e0c3');

--- a/tests/CrowdinApiClient/Api/Enterprise/TranslationApiTest.php
+++ b/tests/CrowdinApiClient/Api/Enterprise/TranslationApiTest.php
@@ -48,8 +48,7 @@ class TranslationApiTest extends AbstractTestApi
                     "createdAt": "2019-09-20T14:05:50+00:00",
                     "updatedAt": "2019-09-20T14:05:50+00:00",
                     "startedAt": "2019-11-13T08:17:22Z",
-                    "finishedAt": "2019-11-13T08:17:22Z",
-                    "eta": "10 seconds"
+                    "finishedAt": "2019-11-13T08:17:22Z"
                   }
                 }'
         ]);
@@ -85,8 +84,7 @@ class TranslationApiTest extends AbstractTestApi
                 "createdAt": "2019-09-20T14:05:50+00:00",
                 "updatedAt": "2019-09-20T14:05:50+00:00",
                 "startedAt": "2019-11-13T08:17:22Z",
-                "finishedAt": "2019-11-13T08:17:22Z",
-                "eta": "10 seconds"
+                "finishedAt": "2019-11-13T08:17:22Z"
               }
             }');
 

--- a/tests/CrowdinApiClient/Api/GlossaryApiTest.php
+++ b/tests/CrowdinApiClient/Api/GlossaryApiTest.php
@@ -160,8 +160,7 @@ class GlossaryApiTest extends AbstractTestApi
                     "createdAt": "2019-09-23T07:06:43+00:00",
                     "updatedAt": "2019-09-23T07:06:43+00:00",
                     "startedAt": "2019-11-13T08:17:23Z",
-                    "finishedAt": "2019-11-13T08:17:23Z",
-                    "eta": "1 second"
+                    "finishedAt": "2019-11-13T08:17:23Z"
                   }
                 }'
         ]);
@@ -214,8 +213,7 @@ class GlossaryApiTest extends AbstractTestApi
                     "createdAt": "2019-09-23T12:17:54+00:00",
                     "updatedAt": "2019-09-23T12:17:54+00:00",
                     "startedAt": "2019-12-04T13:14:36Z",
-                    "finishedAt": "2019-12-04T13:14:36Z",
-                    "eta": "1 second"
+                    "finishedAt": "2019-12-04T13:14:36Z"
                   }
                 }'
         ]);
@@ -247,8 +245,7 @@ class GlossaryApiTest extends AbstractTestApi
                 "createdAt": "2019-09-23T12:17:54+00:00",
                 "updatedAt": "2019-09-23T12:17:54+00:00",
                 "startedAt": "2019-12-04T13:14:36Z",
-                "finishedAt": "2019-12-04T13:14:36Z",
-                "eta": "1 second"
+                "finishedAt": "2019-12-04T13:14:36Z"
               }
             }');
 

--- a/tests/CrowdinApiClient/Api/ReportApiTest.php
+++ b/tests/CrowdinApiClient/Api/ReportApiTest.php
@@ -26,8 +26,7 @@ class ReportApiTest extends AbstractTestApi
                   "createdAt": "2019-09-23T11:26:54+00:00",
                   "updatedAt": "2019-09-23T11:26:54+00:00",
                   "startedAt": "2019-09-23T11:26:54+00:00",
-                  "finishedAt": "2019-09-23T11:26:54+00:00",
-                  "eta": "1 second"
+                  "finishedAt": "2019-09-23T11:26:54+00:00"
                 }'
         ]);
 
@@ -92,8 +91,7 @@ class ReportApiTest extends AbstractTestApi
               "createdAt": "2019-09-23T11:26:54+00:00",
               "updatedAt": "2019-09-23T11:26:54+00:00",
               "startedAt": "2019-09-23T11:26:54+00:00",
-              "finishedAt": "2019-09-23T11:26:54+00:00",
-              "eta": "1 second"
+              "finishedAt": "2019-09-23T11:26:54+00:00"
             }');
 
         $report = $this->crowdin->report->get(124, '50fb3506-4127-4ba8-8296-f97dc7e3e0c3');

--- a/tests/CrowdinApiClient/Api/TranslationApiTest.php
+++ b/tests/CrowdinApiClient/Api/TranslationApiTest.php
@@ -48,8 +48,7 @@ class TranslationApiTest extends AbstractTestApi
                     "createdAt": "2019-09-20T14:05:50+00:00",
                     "updatedAt": "2019-09-20T14:05:50+00:00",
                     "startedAt": "2019-11-13T08:17:22Z",
-                    "finishedAt": "2019-11-13T08:17:22Z",
-                    "eta": "10 seconds"
+                    "finishedAt": "2019-11-13T08:17:22Z"
                   }
                 }'
         ]);
@@ -85,8 +84,7 @@ class TranslationApiTest extends AbstractTestApi
                 "createdAt": "2019-09-20T14:05:50+00:00",
                 "updatedAt": "2019-09-20T14:05:50+00:00",
                 "startedAt": "2019-11-13T08:17:22Z",
-                "finishedAt": "2019-11-13T08:17:22Z",
-                "eta": "10 seconds"
+                "finishedAt": "2019-11-13T08:17:22Z"
               }
             }');
 

--- a/tests/CrowdinApiClient/Api/TranslationMemoryApiTest.php
+++ b/tests/CrowdinApiClient/Api/TranslationMemoryApiTest.php
@@ -177,8 +177,7 @@ class TranslationMemoryApiTest extends AbstractTestApi
                 "createdAt": "2019-09-23T11:26:54+00:00",
                 "updatedAt": "2019-09-23T11:26:54+00:00",
                 "startedAt": "2019-09-23T11:26:54+00:00",
-                "finishedAt": "2019-09-23T11:26:54+00:00",
-                "eta": "1 second"
+                "finishedAt": "2019-09-23T11:26:54+00:00"
               }
             }'
         ]);
@@ -205,8 +204,7 @@ class TranslationMemoryApiTest extends AbstractTestApi
                 "createdAt": "2019-09-23T11:26:54+00:00",
                 "updatedAt": "2019-09-23T11:26:54+00:00",
                 "startedAt": "2019-09-23T11:26:54+00:00",
-                "finishedAt": "2019-09-23T11:26:54+00:00",
-                "eta": "1 second"
+                "finishedAt": "2019-09-23T11:26:54+00:00"
               }
             }');
 
@@ -253,8 +251,7 @@ class TranslationMemoryApiTest extends AbstractTestApi
                         "createdAt": "2019-09-23T11:51:08+00:00",
                         "updatedAt": "2019-09-23T11:51:08+00:00",
                         "startedAt": "string",
-                        "finishedAt": "string",
-                        "eta": "1 second"
+                        "finishedAt": "string"
                       }
                     }'
         ]);
@@ -286,8 +283,7 @@ class TranslationMemoryApiTest extends AbstractTestApi
                 "createdAt": "2019-09-23T11:51:08+00:00",
                 "updatedAt": "2019-09-23T11:51:08+00:00",
                 "startedAt": "string",
-                "finishedAt": "string",
-                "eta": "1 second"
+                "finishedAt": "string"
               }
             }');
 

--- a/tests/CrowdinApiClient/Model/GlossaryExportTest.php
+++ b/tests/CrowdinApiClient/Model/GlossaryExportTest.php
@@ -32,7 +32,6 @@ class GlossaryExportTest extends TestCase
         'updatedAt' => '2019-09-23T07:06:43+00:00',
         'startedAt' => '2019-11-14T09:29:33Z',
         'finishedAt' => '2019-11-14T09:29:33Z',
-        'eta' => '1 second',
     ];
 
     public function testLoadData()
@@ -53,7 +52,6 @@ class GlossaryExportTest extends TestCase
         $this->glossaryExport->setUpdatedAt($this->data['updatedAt']);
         $this->glossaryExport->setStartedAt($this->data['startedAt']);
         $this->glossaryExport->setFinishedAt($this->data['finishedAt']);
-        $this->glossaryExport->setEta($this->data['eta']);
         $this->checkData();
     }
 
@@ -67,6 +65,5 @@ class GlossaryExportTest extends TestCase
         $this->assertEquals($this->data['updatedAt'], $this->glossaryExport->getUpdatedAt());
         $this->assertEquals($this->data['startedAt'], $this->glossaryExport->getStartedAt());
         $this->assertEquals($this->data['finishedAt'], $this->glossaryExport->getFinishedAt());
-        $this->assertEquals($this->data['eta'], $this->glossaryExport->getEta());
     }
 }

--- a/tests/CrowdinApiClient/Model/GlossaryImportImportTest.php
+++ b/tests/CrowdinApiClient/Model/GlossaryImportImportTest.php
@@ -28,7 +28,6 @@ class GlossaryImportImportTest extends TestCase
         'updatedAt' => '2019-09-23T11:26:54+00:00',
         'startedAt' => '2019-09-23T11:26:54+00:00',
         'finishedAt' => '2019-09-23T11:26:54+00:00',
-        'eta' => '1 second',
     ];
 
     public function testLoadData()
@@ -47,6 +46,5 @@ class GlossaryImportImportTest extends TestCase
         $this->assertEquals($this->data['updatedAt'], $this->glossaryImport->getUpdatedAt());
         $this->assertEquals($this->data['startedAt'], $this->glossaryImport->getStartedAt());
         $this->assertEquals($this->data['finishedAt'], $this->glossaryImport->getFinishedAt());
-        $this->assertEquals($this->data['eta'], $this->glossaryImport->getEta());
     }
 }

--- a/tests/CrowdinApiClient/Model/PreTranslationTest.php
+++ b/tests/CrowdinApiClient/Model/PreTranslationTest.php
@@ -46,7 +46,6 @@ class PreTranslationTest extends TestCase
         'updatedAt' => '2019-09-20T14:05:50+00:00',
         'startedAt' => '2019-11-14T09:29:32Z',
         'finishedAt' => '2019-11-14T09:29:32Z',
-        'eta' => '10 seconds',
     ];
 
     public function testLoadData()
@@ -66,7 +65,6 @@ class PreTranslationTest extends TestCase
         $this->preTranslation->setUpdatedAt($this->data['updatedAt']);
         $this->preTranslation->setStartedAt($this->data['startedAt']);
         $this->preTranslation->setFinishedAt($this->data['finishedAt']);
-        $this->preTranslation->setEta($this->data['eta']);
         $this->checkData();
     }
 
@@ -80,6 +78,5 @@ class PreTranslationTest extends TestCase
         $this->assertEquals($this->data['updatedAt'], $this->preTranslation->getUpdatedAt());
         $this->assertEquals($this->data['startedAt'], $this->preTranslation->getStartedAt());
         $this->assertEquals($this->data['finishedAt'], $this->preTranslation->getFinishedAt());
-        $this->assertEquals($this->data['eta'], $this->preTranslation->getEta());
     }
 }

--- a/tests/CrowdinApiClient/Model/ReportTest.php
+++ b/tests/CrowdinApiClient/Model/ReportTest.php
@@ -37,7 +37,6 @@ class ReportTest extends TestCase
         'updatedAt' => '2019-09-23T11:26:54+00:00',
         'startedAt' => '2019-09-23T11:26:54+00:00',
         'finishedAt' => '2019-09-23T11:26:54+00:00',
-        'eta' => '1 second',
     ];
 
     /**
@@ -62,7 +61,6 @@ class ReportTest extends TestCase
         $this->report->setUpdatedAt($this->data['updatedAt']);
         $this->report->setStartedAt($this->data['startedAt']);
         $this->report->setFinishedAt($this->data['finishedAt']);
-        $this->report->setEta($this->data['eta']);
         $this->checkData();
     }
 
@@ -76,6 +74,5 @@ class ReportTest extends TestCase
         $this->assertEquals($this->data['updatedAt'], $this->report->getUpdatedAt());
         $this->assertEquals($this->data['startedAt'], $this->report->getStartedAt());
         $this->assertEquals($this->data['finishedAt'], $this->report->getFinishedAt());
-        $this->assertEquals($this->data['eta'], $this->report->getEta());
     }
 }

--- a/tests/CrowdinApiClient/Model/TranslationMemoryExportTest.php
+++ b/tests/CrowdinApiClient/Model/TranslationMemoryExportTest.php
@@ -25,7 +25,6 @@ class TranslationMemoryExportTest extends TestCase
         'updatedAt' => '2019-09-23T11:26:54+00:00',
         'startedAt' => '2019-09-23T11:26:54+00:00',
         'finishedAt' => '2019-09-23T11:26:54+00:00',
-        'eta' => '1 second',
     ];
 
     public function testLoadData()
@@ -46,7 +45,6 @@ class TranslationMemoryExportTest extends TestCase
         $this->translationMemoryExport->setUpdatedAt($this->data['updatedAt']);
         $this->translationMemoryExport->setStartedAt($this->data['startedAt']);
         $this->translationMemoryExport->setFinishedAt($this->data['finishedAt']);
-        $this->translationMemoryExport->setEta($this->data['eta']);
         $this->checkData();
     }
 
@@ -60,6 +58,5 @@ class TranslationMemoryExportTest extends TestCase
         $this->assertEquals($this->data['updatedAt'], $this->translationMemoryExport->getUpdatedAt());
         $this->assertEquals($this->data['startedAt'], $this->translationMemoryExport->getStartedAt());
         $this->assertEquals($this->data['finishedAt'], $this->translationMemoryExport->getFinishedAt());
-        $this->assertEquals($this->data['eta'], $this->translationMemoryExport->getEta());
     }
 }

--- a/tests/CrowdinApiClient/Model/TranslationMemoryImportTest.php
+++ b/tests/CrowdinApiClient/Model/TranslationMemoryImportTest.php
@@ -28,7 +28,6 @@ class TranslationMemoryImportTest extends TestCase
         'updatedAt' => '2019-09-23T11:26:54+00:00',
         'startedAt' => '2019-09-23T11:26:54+00:00',
         'finishedAt' => '2019-09-23T11:26:54+00:00',
-        'eta' => '1 second',
     ];
 
     public function testLoadData()
@@ -49,7 +48,6 @@ class TranslationMemoryImportTest extends TestCase
         $this->translationMemoryImport->setUpdatedAt($this->data['updatedAt']);
         $this->translationMemoryImport->setStartedAt($this->data['startedAt']);
         $this->translationMemoryImport->setFinishedAt($this->data['finishedAt']);
-        $this->translationMemoryImport->setEta($this->data['eta']);
         $this->checkData();
     }
 
@@ -63,6 +61,5 @@ class TranslationMemoryImportTest extends TestCase
         $this->assertEquals($this->data['updatedAt'], $this->translationMemoryImport->getUpdatedAt());
         $this->assertEquals($this->data['startedAt'], $this->translationMemoryImport->getStartedAt());
         $this->assertEquals($this->data['finishedAt'], $this->translationMemoryImport->getFinishedAt());
-        $this->assertEquals($this->data['eta'], $this->translationMemoryImport->getEta());
     }
 }


### PR DESCRIPTION
removed 'eta' parameters from all Reports, Import and Export response model: GlossaryExport, GlossaryImport, PreTranslation, Report, TranslationMemoryExport, TranslationMemoryImport.