### PR TITLE
Add package discovery for Laravel

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,5 +35,12 @@
         "psr-4": {
             "CrowdinApiClient\\Tests\\": "tests/CrowdinApiClient/"
         }
+    },
+    "extra": {
+        "laravel": {
+            "providers": [
+                "CrowdinApiClient\\FrameworkSupport\\Laravel\\CrowdinServiceProvider"
+            ]
+        }
     }
 }


### PR DESCRIPTION
This PR adds package discovery for Laravel.

I noticed while installing this into a Laravel project that while this package supports Laravel and has a service provider for it, it was never added to the `extra` key in the `composer.json` file.

For more information regarding this please refer to the [Package Discovery section of the Laravel docs](https://laravel.com/docs/8.x/packages#package-discovery).