### PR TITLE
Adding isDuplicate and masterStringId to the SourceString Model

### DIFF
--- a/src/CrowdinApiClient/Model/SourceString.php
+++ b/src/CrowdinApiClient/Model/SourceString.php
@@ -93,6 +93,16 @@ class SourceString extends BaseModel
     protected $updatedAt;
 
     /**
+     * @var bool
+     */
+    protected $isDuplicate = false;
+
+    /**
+     * @var ?integer
+     */
+    protected $masterStringId;
+
+    /**
      * @param array $data
      */
     public function __construct(array $data = [])
@@ -116,6 +126,8 @@ class SourceString extends BaseModel
         $this->labelIds = (array)$this->getDataProperty('labelIds');
         $this->createdAt = (string)$this->getDataProperty('createdAt');
         $this->updatedAt = (string)$this->getDataProperty('updatedAt');
+        $this->isDuplicate = (bool)$this->getDataProperty('isDuplicate');
+        $this->masterStringId = $this->getDataProperty('masterStringId');
     }
 
     /**
@@ -292,5 +304,21 @@ class SourceString extends BaseModel
     public function getUpdatedAt(): string
     {
         return $this->updatedAt;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isDuplicate(): bool
+    {
+        return $this->isDuplicate;
+    }
+
+    /**
+     * @return int|null
+     */
+    public function getMasterStringId(): ?int
+    {
+        return $this->masterStringId;
     }
 }

--- a/tests/CrowdinApiClient/Api/SourceStringApiTest.php
+++ b/tests/CrowdinApiClient/Api/SourceStringApiTest.php
@@ -94,7 +94,8 @@ class SourceStringApiTest extends AbstractTestApi
                     "hasPlurals": false,
                     "isIcu": false,
                     "createdAt": "2019-09-20T12:43:57+00:00",
-                    "updatedAt": "2019-09-20T13:24:01+00:00"
+                    "updatedAt": "2019-09-20T13:24:01+00:00",
+                    "isDuplicate": false,
                   }
                 }'
         );

--- a/tests/CrowdinApiClient/Model/SourceStringTest.php
+++ b/tests/CrowdinApiClient/Model/SourceStringTest.php
@@ -34,6 +34,8 @@ class SourceStringTest extends TestCase
         'labelIds' => [1],
         'createdAt' => '2019-09-20T12:43:57+00:00',
         'updatedAt' => '2019-09-20T13:24:01+00:00',
+        'isDuplicate' => true,
+        'masterStringId' => 1234
     ];
 
     public function testLoadData()
@@ -76,5 +78,7 @@ class SourceStringTest extends TestCase
         $this->assertEquals($this->data['labelIds'], $this->sourceString->getLabelIds());
         $this->assertEquals($this->data['createdAt'], $this->sourceString->getCreatedAt());
         $this->assertEquals($this->data['updatedAt'], $this->sourceString->getUpdatedAt());
+        $this->assertEquals($this->data['isDuplicate'], $this->sourceString->isDuplicate());
+        $this->assertEquals($this->data['masterStringId'], $this->sourceString->getMasterStringId());
     }
 }


### PR DESCRIPTION
I added the `isDuplicate` and the `masterStringId` property to the SourceString Model. Going through the code it appears that these did not require setters. Let me know if this is not what you had in mind and indications of what may need to change to be more inline with the requirements