### PR TITLE
Collection: Suppress deprecations for PHP 8.1

### DIFF
--- a/src/CrowdinApiClient/Collection.php
+++ b/src/CrowdinApiClient/Collection.php
@@ -28,6 +28,7 @@ class Collection implements IteratorAggregate, ArrayAccess, Countable
      * The return value is cast to an integer.
      * @since 5.1.0
      */
+    #[\ReturnTypeWillChange]
     public function count()
     {
         return sizeof($this->_items);
@@ -40,6 +41,7 @@ class Collection implements IteratorAggregate, ArrayAccess, Countable
      * <b>Traversable</b>
      * @since 5.0.0
      */
+    #[\ReturnTypeWillChange]
     public function getIterator()
     {
         return new CollectionIterator($this->_items);
@@ -57,6 +59,7 @@ class Collection implements IteratorAggregate, ArrayAccess, Countable
      * The return value will be casted to boolean if non-boolean was returned.
      * @since 5.0.0
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->_items[$offset]);


### PR DESCRIPTION
While updating our PHP version to 8.1, we got deprecation warnings regarding the use of `IteratorAggregate`. This just suppresses those warnings for now.

Connects: https://github.com/crowdin/crowdin-api-client-php/issues/124