### PR TITLE
Collection: Fix php 8.1 warnings

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -6,6 +6,7 @@
          convertErrorsToExceptions="true"
          convertNoticesToExceptions="true"
          convertWarningsToExceptions="true"
+         convertDeprecationsToExceptions="true"
          processIsolation="false"
          stopOnFailure="false">
     <testsuites>

--- a/src/CrowdinApiClient/Collection.php
+++ b/src/CrowdinApiClient/Collection.php
@@ -28,7 +28,8 @@ class Collection implements IteratorAggregate, ArrayAccess, Countable
      * The return value is cast to an integer.
      * @since 5.1.0
      */
-    public function count(): int
+    #[\ReturnTypeWillChange]
+    public function count()
     {
         return sizeof($this->_items);
     }
@@ -40,7 +41,8 @@ class Collection implements IteratorAggregate, ArrayAccess, Countable
      * <b>Traversable</b>
      * @since 5.0.0
      */
-    public function getIterator(): CollectionIterator
+    #[\ReturnTypeWillChange]
+    public function getIterator()
     {
         return new CollectionIterator($this->_items);
     }
@@ -57,7 +59,8 @@ class Collection implements IteratorAggregate, ArrayAccess, Countable
      * The return value will be casted to boolean if non-boolean was returned.
      * @since 5.0.0
      */
-    public function offsetExists($offset): bool
+    #[\ReturnTypeWillChange]
+    public function offsetExists($offset)
     {
         return isset($this->_items[$offset]);
     }
@@ -92,7 +95,8 @@ class Collection implements IteratorAggregate, ArrayAccess, Countable
      * @return void
      * @since 5.0.0
      */
-    public function offsetSet($offset, $value): void
+    #[\ReturnTypeWillChange]
+    public function offsetSet($offset, $value)
     {
         if ($offset === null) {
             $offset = max(array_keys($this->_items)) + 1;
@@ -109,7 +113,8 @@ class Collection implements IteratorAggregate, ArrayAccess, Countable
      * @return void
      * @since 5.0.0
      */
-    public function offsetUnset($offset): void
+    #[\ReturnTypeWillChange]
+    public function offsetUnset($offset)
     {
         unset($this->_items[$offset]);
     }

--- a/src/CrowdinApiClient/Collection.php
+++ b/src/CrowdinApiClient/Collection.php
@@ -71,7 +71,8 @@ class Collection implements IteratorAggregate, ArrayAccess, Countable
      * @return mixed Can return all value types.
      * @since 5.0.0
      */
-    public function offsetGet($offset): mixed
+    #[\ReturnTypeWillChange]
+    public function offsetGet($offset)
     {
         if (isset($this->_items[$offset]) === false) {
             return null;

--- a/src/CrowdinApiClient/Collection.php
+++ b/src/CrowdinApiClient/Collection.php
@@ -27,6 +27,7 @@ class Collection implements IteratorAggregate, ArrayAccess, Countable
      * <p>
      * The return value is cast to an integer.
      * @since 5.1.0
+     * @TODO Remove the 'ReturnTypeWillChange' suppression on next major version
      */
     #[\ReturnTypeWillChange]
     public function count()
@@ -40,6 +41,7 @@ class Collection implements IteratorAggregate, ArrayAccess, Countable
      * @return CollectionIterator
      * <b>Traversable</b>
      * @since 5.0.0
+     * @TODO Remove the 'ReturnTypeWillChange' suppression on next major version
      */
     #[\ReturnTypeWillChange]
     public function getIterator()
@@ -58,6 +60,7 @@ class Collection implements IteratorAggregate, ArrayAccess, Countable
      * <p>
      * The return value will be casted to boolean if non-boolean was returned.
      * @since 5.0.0
+     * @TODO Remove the 'ReturnTypeWillChange' suppression on next major version
      */
     #[\ReturnTypeWillChange]
     public function offsetExists($offset)
@@ -73,6 +76,7 @@ class Collection implements IteratorAggregate, ArrayAccess, Countable
      * </p>
      * @return mixed Can return all value types.
      * @since 5.0.0
+     * @TODO Remove the 'ReturnTypeWillChange' suppression on next major version
      */
     #[\ReturnTypeWillChange]
     public function offsetGet($offset)
@@ -94,6 +98,7 @@ class Collection implements IteratorAggregate, ArrayAccess, Countable
      * </p>
      * @return void
      * @since 5.0.0
+     * @TODO Remove the 'ReturnTypeWillChange' suppression on next major version
      */
     #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
@@ -112,6 +117,7 @@ class Collection implements IteratorAggregate, ArrayAccess, Countable
      * </p>
      * @return void
      * @since 5.0.0
+     * @TODO Remove the 'ReturnTypeWillChange' suppression on next major version
      */
     #[\ReturnTypeWillChange]
     public function offsetUnset($offset)

--- a/src/CrowdinApiClient/Collection.php
+++ b/src/CrowdinApiClient/Collection.php
@@ -74,6 +74,7 @@ class Collection implements IteratorAggregate, ArrayAccess, Countable
      * @return mixed Can return all value types.
      * @since 5.0.0
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         if (isset($this->_items[$offset]) === false) {
@@ -94,6 +95,7 @@ class Collection implements IteratorAggregate, ArrayAccess, Countable
      * @return void
      * @since 5.0.0
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if ($offset === null) {
@@ -111,6 +113,7 @@ class Collection implements IteratorAggregate, ArrayAccess, Countable
      * @return void
      * @since 5.0.0
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->_items[$offset]);

--- a/src/CrowdinApiClient/Collection.php
+++ b/src/CrowdinApiClient/Collection.php
@@ -28,8 +28,7 @@ class Collection implements IteratorAggregate, ArrayAccess, Countable
      * The return value is cast to an integer.
      * @since 5.1.0
      */
-    #[\ReturnTypeWillChange]
-    public function count()
+    public function count(): int
     {
         return sizeof($this->_items);
     }
@@ -41,8 +40,7 @@ class Collection implements IteratorAggregate, ArrayAccess, Countable
      * <b>Traversable</b>
      * @since 5.0.0
      */
-    #[\ReturnTypeWillChange]
-    public function getIterator()
+    public function getIterator(): CollectionIterator
     {
         return new CollectionIterator($this->_items);
     }
@@ -59,8 +57,7 @@ class Collection implements IteratorAggregate, ArrayAccess, Countable
      * The return value will be casted to boolean if non-boolean was returned.
      * @since 5.0.0
      */
-    #[\ReturnTypeWillChange]
-    public function offsetExists($offset)
+    public function offsetExists($offset): bool
     {
         return isset($this->_items[$offset]);
     }
@@ -74,8 +71,7 @@ class Collection implements IteratorAggregate, ArrayAccess, Countable
      * @return mixed Can return all value types.
      * @since 5.0.0
      */
-    #[\ReturnTypeWillChange]
-    public function offsetGet($offset)
+    public function offsetGet($offset): mixed
     {
         if (isset($this->_items[$offset]) === false) {
             return null;
@@ -95,8 +91,7 @@ class Collection implements IteratorAggregate, ArrayAccess, Countable
      * @return void
      * @since 5.0.0
      */
-    #[\ReturnTypeWillChange]
-    public function offsetSet($offset, $value)
+    public function offsetSet($offset, $value): void
     {
         if ($offset === null) {
             $offset = max(array_keys($this->_items)) + 1;
@@ -113,8 +108,7 @@ class Collection implements IteratorAggregate, ArrayAccess, Countable
      * @return void
      * @since 5.0.0
      */
-    #[\ReturnTypeWillChange]
-    public function offsetUnset($offset)
+    public function offsetUnset($offset): void
     {
         unset($this->_items[$offset]);
     }

--- a/src/CrowdinApiClient/CollectionIterator.php
+++ b/src/CrowdinApiClient/CollectionIterator.php
@@ -30,6 +30,7 @@ class CollectionIterator implements Iterator
      * @link https://php.net/manual/en/iterator.current.php
      * @return mixed Can return any type.
      * @since 5.0.0
+     * @TODO Remove the 'ReturnTypeWillChange' suppression on next major version
      */
     #[\ReturnTypeWillChange]
     public function current()
@@ -43,6 +44,7 @@ class CollectionIterator implements Iterator
      * @link https://php.net/manual/en/iterator.next.php
      * @return mixed Next item
      * @since 5.0.0
+     * @TODO Remove the 'ReturnTypeWillChange' suppression on next major version
      */
     #[\ReturnTypeWillChange]
     public function next()
@@ -56,6 +58,7 @@ class CollectionIterator implements Iterator
      * @link https://php.net/manual/en/iterator.key.php
      * @return mixed scalar on success, or null on failure.
      * @since 5.0.0
+     * @TODO Remove the 'ReturnTypeWillChange' suppression on next major version
      */
     #[\ReturnTypeWillChange]
     public function key()
@@ -70,6 +73,7 @@ class CollectionIterator implements Iterator
      * @return bool The return value will be casted to boolean and then evaluated.
      * Returns true on success or false on failure.
      * @since 5.0.0
+     * @TODO Remove the 'ReturnTypeWillChange' suppression on next major version
      */
     #[\ReturnTypeWillChange]
     public function valid()
@@ -84,6 +88,7 @@ class CollectionIterator implements Iterator
      * @link https://php.net/manual/en/iterator.rewind.php
      * @return void Any returned value is ignored.
      * @since 5.0.0
+     * @TODO Remove the 'ReturnTypeWillChange' suppression on next major version
      */
     #[\ReturnTypeWillChange]
     public function rewind()

--- a/src/CrowdinApiClient/CollectionIterator.php
+++ b/src/CrowdinApiClient/CollectionIterator.php
@@ -44,7 +44,8 @@ class CollectionIterator implements Iterator
      * @return void Any returned value is ignored.
      * @since 5.0.0
      */
-    public function next(): void
+    #[\ReturnTypeWillChange]
+    public function next()
     {
         next($this->_items);
 
@@ -70,7 +71,8 @@ class CollectionIterator implements Iterator
      * Returns true on success or false on failure.
      * @since 5.0.0
      */
-    public function valid(): bool
+    #[\ReturnTypeWillChange]
+    public function valid()
     {
         $key = key($this->_items);
         $var = ($key !== null && $key !== false);
@@ -83,7 +85,8 @@ class CollectionIterator implements Iterator
      * @return void Any returned value is ignored.
      * @since 5.0.0
      */
-    public function rewind(): void
+    #[\ReturnTypeWillChange]
+    public function rewind()
     {
         reset($this->_items);
     }

--- a/src/CrowdinApiClient/CollectionIterator.php
+++ b/src/CrowdinApiClient/CollectionIterator.php
@@ -31,7 +31,8 @@ class CollectionIterator implements Iterator
      * @return mixed Can return any type.
      * @since 5.0.0
      */
-    public function current(): mixed
+    #[\ReturnTypeWillChange]
+    public function current()
     {
         $var = current($this->_items);
         return $var;
@@ -55,7 +56,8 @@ class CollectionIterator implements Iterator
      * @return mixed scalar on success, or null on failure.
      * @since 5.0.0
      */
-    public function key(): mixed
+    #[\ReturnTypeWillChange]
+    public function key()
     {
         $var = key($this->_items);
         return $var;

--- a/src/CrowdinApiClient/CollectionIterator.php
+++ b/src/CrowdinApiClient/CollectionIterator.php
@@ -41,14 +41,14 @@ class CollectionIterator implements Iterator
     /**
      * Move forward to next element
      * @link https://php.net/manual/en/iterator.next.php
-     * @return void Any returned value is ignored.
+     * @return mixed Next item
      * @since 5.0.0
      */
     #[\ReturnTypeWillChange]
     public function next()
     {
-        next($this->_items);
-
+        $var = next($this->_items);
+        return $var;
     }
 
     /**

--- a/src/CrowdinApiClient/CollectionIterator.php
+++ b/src/CrowdinApiClient/CollectionIterator.php
@@ -31,7 +31,7 @@ class CollectionIterator implements Iterator
      * @return mixed Can return any type.
      * @since 5.0.0
      */
-    public function current()
+    public function current(): mixed
     {
         $var = current($this->_items);
         return $var;
@@ -40,13 +40,13 @@ class CollectionIterator implements Iterator
     /**
      * Move forward to next element
      * @link https://php.net/manual/en/iterator.next.php
-     * @return mixed Next item
+     * @return void Any returned value is ignored.
      * @since 5.0.0
      */
-    public function next()
+    public function next(): void
     {
-        $var = next($this->_items);
-        return $var;
+        next($this->_items);
+
     }
 
     /**
@@ -55,7 +55,7 @@ class CollectionIterator implements Iterator
      * @return mixed scalar on success, or null on failure.
      * @since 5.0.0
      */
-    public function key()
+    public function key(): mixed
     {
         $var = key($this->_items);
         return $var;
@@ -68,7 +68,7 @@ class CollectionIterator implements Iterator
      * Returns true on success or false on failure.
      * @since 5.0.0
      */
-    public function valid()
+    public function valid(): bool
     {
         $key = key($this->_items);
         $var = ($key !== null && $key !== false);
@@ -81,7 +81,7 @@ class CollectionIterator implements Iterator
      * @return void Any returned value is ignored.
      * @since 5.0.0
      */
-    public function rewind()
+    public function rewind(): void
     {
         reset($this->_items);
     }

--- a/tests/CrowdinApiClient/CollectionIteratorTest.php
+++ b/tests/CrowdinApiClient/CollectionIteratorTest.php
@@ -16,7 +16,8 @@ class CollectionIteratorTest extends TestCase
         $this->assertEquals('one', $collection->current());
         $this->assertEquals(0, $collection->key());
         $this->assertTrue($collection->valid());
-        $this->assertEquals('two', $collection->next());
+        $collection->next();
+        $this->assertEquals('two', $collection->current());
         $collection->rewind();
         $this->assertEquals('one', $collection->current());
     }

--- a/tests/CrowdinApiClient/CollectionIteratorTest.php
+++ b/tests/CrowdinApiClient/CollectionIteratorTest.php
@@ -16,8 +16,7 @@ class CollectionIteratorTest extends TestCase
         $this->assertEquals('one', $collection->current());
         $this->assertEquals(0, $collection->key());
         $this->assertTrue($collection->valid());
-        $collection->next();
-        $this->assertEquals('two', $collection->current());
+        $this->assertEquals('two', $collection->next());
         $collection->rewind();
         $this->assertEquals('one', $collection->current());
     }


### PR DESCRIPTION
Whoops, I seem to have missed a few of these accidentally in https://github.com/crowdin/crowdin-api-client-php/pull/125. Sorry about that. This fixes (or suppresses) the incompatible type warnings.

Connects: https://github.com/crowdin/crowdin-api-client-php/issues/124