### PR TITLE
Updating the glossary download 

### DIFF
--- a/src/CrowdinApiClient/Api/GlossaryApi.php
+++ b/src/CrowdinApiClient/Api/GlossaryApi.php
@@ -123,8 +123,8 @@ class GlossaryApi extends AbstractApi
 
 	/**
      * Download Glossary
-     * @link https://developer.crowdin.com/api/v2/#operation/api.glossaries.exports.download.getMany API Documentation
-     * @link https://developer.crowdin.com/enterprise/api/v2/#operation/api.glossaries.exports.download.getMany API Documentation Enterprise
+     * @link https://developer.crowdin.com/api/v2/#operation/api.glossaries.exports.download.download API Documentation
+     * @link https://developer.crowdin.com/enterprise/api/v2/#operation/api.glossaries.exports.download.download API Documentation Enterprise
      *
      * @param int $glossaryId
 	 * @param string $exportId

--- a/src/CrowdinApiClient/Api/GlossaryApi.php
+++ b/src/CrowdinApiClient/Api/GlossaryApi.php
@@ -121,17 +121,18 @@ class GlossaryApi extends AbstractApi
         return $this->_get($path, GlossaryExport::class);
     }
 
-    /**
+	/**
      * Download Glossary
      * @link https://developer.crowdin.com/api/v2/#operation/api.glossaries.exports.download.getMany API Documentation
      * @link https://developer.crowdin.com/enterprise/api/v2/#operation/api.glossaries.exports.download.getMany API Documentation Enterprise
      *
      * @param int $glossaryId
+	 * @param string $exportId
      * @return DownloadFile|null
      */
-    public function download(int $glossaryId): ?DownloadFile
+    public function download(int $glossaryId, string $exportId): ?DownloadFile
     {
-        $path = sprintf('glossaries/%d/exports/download', $glossaryId);
+        $path = sprintf('glossaries/%d/exports/%s/download', $glossaryId, $exportId);
         return $this->_get($path, DownloadFile::class);
     }
 

--- a/src/CrowdinApiClient/Api/GlossaryApi.php
+++ b/src/CrowdinApiClient/Api/GlossaryApi.php
@@ -121,13 +121,13 @@ class GlossaryApi extends AbstractApi
         return $this->_get($path, GlossaryExport::class);
     }
 
-	/**
+    /**
      * Download Glossary
      * @link https://developer.crowdin.com/api/v2/#operation/api.glossaries.exports.download.download API Documentation
      * @link https://developer.crowdin.com/enterprise/api/v2/#operation/api.glossaries.exports.download.download API Documentation Enterprise
      *
      * @param int $glossaryId
-	 * @param string $exportId
+     * @param string $exportId
      * @return DownloadFile|null
      */
     public function download(int $glossaryId, string $exportId): ?DownloadFile

--- a/tests/CrowdinApiClient/Api/Enterprise/GlossaryApiTest.php
+++ b/tests/CrowdinApiClient/Api/Enterprise/GlossaryApiTest.php
@@ -171,14 +171,14 @@ class GlossaryApiTest extends AbstractTestApi
 
     public function testDownload()
     {
-        $this->mockRequestGet('/glossaries/2/exports/download', '{
+        $this->mockRequestGet('/glossaries/2/exports/5ed2ce93-6d47-4402-9e66-516ca835cb20/download', '{
           "data": {
             "url": "https://production-enterprise-importer.downloads.crowdin.com/992000002/2/14.xliff?response-content-disposition=attachment%3B%20filename%3D%22APP.xliff%22&X-Amz-Content-Sha256=UNSIGNED-PAYLOAD&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIGJKLQV66ZXPMMEA%2F20190920%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20190920T093121Z&X-Amz-SignedHeaders=host&X-Amz-Expires=3600&X-Amz-Signature=439ebd69a1b7e4c23e6d17891a491c94f832e0c82e4692dedb35a6cd1e624b62",
             "expireIn": "2019-09-20T10:31:21+00:00"
           }
         }');
 
-        $downloadFile = $this->crowdin->glossary->download(2);
+        $downloadFile = $this->crowdin->glossary->download(2, '5ed2ce93-6d47-4402-9e66-516ca835cb20');
         $this->assertInstanceOf(DownloadFile::class, $downloadFile);
         $this->assertEquals('https://production-enterprise-importer.downloads.crowdin.com/992000002/2/14.xliff?response-content-disposition=attachment%3B%20filename%3D%22APP.xliff%22&X-Amz-Content-Sha256=UNSIGNED-PAYLOAD&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIGJKLQV66ZXPMMEA%2F20190920%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20190920T093121Z&X-Amz-SignedHeaders=host&X-Amz-Expires=3600&X-Amz-Signature=439ebd69a1b7e4c23e6d17891a491c94f832e0c82e4692dedb35a6cd1e624b62', $downloadFile->getUrl());
     }

--- a/tests/CrowdinApiClient/Api/GlossaryApiTest.php
+++ b/tests/CrowdinApiClient/Api/GlossaryApiTest.php
@@ -172,14 +172,14 @@ class GlossaryApiTest extends AbstractTestApi
 
     public function testDownload()
     {
-        $this->mockRequestGet('/glossaries/2/exports/download', '{
+        $this->mockRequestGet('/glossaries/2/exports/5ed2ce93-6d47-4402-9e66-516ca835cb20/download', '{
           "data": {
             "url": "https://production-enterprise-importer.downloads.crowdin.com/992000002/2/14.xliff?response-content-disposition=attachment%3B%20filename%3D%22APP.xliff%22&X-Amz-Content-Sha256=UNSIGNED-PAYLOAD&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIGJKLQV66ZXPMMEA%2F20190920%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20190920T093121Z&X-Amz-SignedHeaders=host&X-Amz-Expires=3600&X-Amz-Signature=439ebd69a1b7e4c23e6d17891a491c94f832e0c82e4692dedb35a6cd1e624b62",
             "expireIn": "2019-09-20T10:31:21+00:00"
           }
         }');
 
-        $downloadFile = $this->crowdin->glossary->download(2);
+        $downloadFile = $this->crowdin->glossary->download(2, '5ed2ce93-6d47-4402-9e66-516ca835cb20');
         $this->assertInstanceOf(DownloadFile::class, $downloadFile);
         $this->assertEquals('https://production-enterprise-importer.downloads.crowdin.com/992000002/2/14.xliff?response-content-disposition=attachment%3B%20filename%3D%22APP.xliff%22&X-Amz-Content-Sha256=UNSIGNED-PAYLOAD&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIGJKLQV66ZXPMMEA%2F20190920%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20190920T093121Z&X-Amz-SignedHeaders=host&X-Amz-Expires=3600&X-Amz-Signature=439ebd69a1b7e4c23e6d17891a491c94f832e0c82e4692dedb35a6cd1e624b62', $downloadFile->getUrl());
     }


### PR DESCRIPTION
Fixing the download glossary method to include the exportId as per the API documentation