### PR TITLE
feat: Add glossary exportfields

### DIFF
--- a/src/CrowdinApiClient/Api/GlossaryApi.php
+++ b/src/CrowdinApiClient/Api/GlossaryApi.php
@@ -99,7 +99,7 @@ class GlossaryApi extends AbstractApi
 	 * @param array $exportFields
      * @return GlossaryExport|null
      */
-    public function export(int $glossaryId, $format = 'tbx', $exportFields = ['term', 'description', 'description']): ?GlossaryExport
+    public function export(int $glossaryId, $format = 'tbx', $exportFields = ['term', 'description', 'partOfSpeech']): ?GlossaryExport
     {
         $path = sprintf('glossaries/%d/exports', $glossaryId);
         $params = ['format' => $format, 'exportFields' => $exportFields];

--- a/src/CrowdinApiClient/Api/GlossaryApi.php
+++ b/src/CrowdinApiClient/Api/GlossaryApi.php
@@ -96,7 +96,7 @@ class GlossaryApi extends AbstractApi
      *
      * @param int $glossaryId
      * @param string $format
-	 * @param array $exportFields
+     * @param array $exportFields
      * @return GlossaryExport|null
      */
     public function export(int $glossaryId, $format = 'tbx', $exportFields = ['term', 'description', 'partOfSpeech']): ?GlossaryExport

--- a/src/CrowdinApiClient/Api/GlossaryApi.php
+++ b/src/CrowdinApiClient/Api/GlossaryApi.php
@@ -96,12 +96,13 @@ class GlossaryApi extends AbstractApi
      *
      * @param int $glossaryId
      * @param string $format
+	 * @param array $exportFields
      * @return GlossaryExport|null
      */
-    public function export(int $glossaryId, $format = 'tbx'): ?GlossaryExport
+    public function export(int $glossaryId, $format = 'tbx', $exportFields = ['term', 'description', 'description']): ?GlossaryExport
     {
         $path = sprintf('glossaries/%d/exports', $glossaryId);
-        $params = ['format' => $format];
+        $params = ['format' => $format, 'exportFields' => $exportFields];
 
         return $this->_post($path, GlossaryExport::class, $params);
     }

--- a/tests/CrowdinApiClient/Api/Enterprise/GlossaryApiTest.php
+++ b/tests/CrowdinApiClient/Api/Enterprise/GlossaryApiTest.php
@@ -145,7 +145,7 @@ class GlossaryApiTest extends AbstractTestApi
             'method' => 'post',
             'body' => [
                 'format' => 'tbx',
-                'exportFields'	=> [ 'term', 'description', 'partOfSpeech' ],
+                'exportFields' => [ 'term', 'description', 'partOfSpeech' ],
             ],
             'response' => '{
                   "data": {

--- a/tests/CrowdinApiClient/Api/Enterprise/GlossaryApiTest.php
+++ b/tests/CrowdinApiClient/Api/Enterprise/GlossaryApiTest.php
@@ -145,6 +145,7 @@ class GlossaryApiTest extends AbstractTestApi
             'method' => 'post',
             'body' => [
                 'format' => 'tbx',
+                'exportFields'	=> [ 'term', 'description', 'partOfSpeech' ],
             ],
             'response' => '{
                   "data": {

--- a/tests/CrowdinApiClient/Api/GlossaryApiTest.php
+++ b/tests/CrowdinApiClient/Api/GlossaryApiTest.php
@@ -146,7 +146,7 @@ class GlossaryApiTest extends AbstractTestApi
             'method' => 'post',
             'body' => [
                 'format' => 'tbx',
-                'exportFields'	=> [ 'term', 'description' ],
+                'exportFields'	=> [ 'term', 'description', 'partOfSpeech' ],
             ],
             'response' => '{
                   "data": {

--- a/tests/CrowdinApiClient/Api/GlossaryApiTest.php
+++ b/tests/CrowdinApiClient/Api/GlossaryApiTest.php
@@ -146,6 +146,7 @@ class GlossaryApiTest extends AbstractTestApi
             'method' => 'post',
             'body' => [
                 'format' => 'tbx',
+                'exportFields'	=> [ 'term', 'description' ],
             ],
             'response' => '{
                   "data": {

--- a/tests/CrowdinApiClient/Api/GlossaryApiTest.php
+++ b/tests/CrowdinApiClient/Api/GlossaryApiTest.php
@@ -146,7 +146,7 @@ class GlossaryApiTest extends AbstractTestApi
             'method' => 'post',
             'body' => [
                 'format' => 'tbx',
-                'exportFields'	=> [ 'term', 'description', 'partOfSpeech' ],
+                'exportFields' => [ 'term', 'description', 'partOfSpeech' ],
             ],
             'response' => '{
                   "data": {


### PR DESCRIPTION
Adding `exportFields` parameter to the glossary export method, to reflect the API - https://developer.crowdin.com/api/v2/#operation/api.glossaries.exports.post