### PR TITLE
fix: Fix AbstractTestApi::mockRequest assertions

### DIFF
--- a/src/CrowdinApiClient/Api/AbstractApi.php
+++ b/src/CrowdinApiClient/Api/AbstractApi.php
@@ -167,7 +167,13 @@ abstract class AbstractApi implements ApiInterface
      */
     protected function _delete(string $path, array $params = [])
     {
-        return $this->client->apiRequest('delete', $path, null, $params);
+        $options = [];
+
+        if (!empty($params)) {
+            $options['params'] = $params;
+        }
+
+        return $this->client->apiRequest('delete', $path, null, $options);
     }
 
     /**

--- a/tests/CrowdinApiClient/Api/AbstractTestApi.php
+++ b/tests/CrowdinApiClient/Api/AbstractTestApi.php
@@ -49,7 +49,7 @@ abstract class AbstractTestApi extends TestCase
             if (isset($params['header'])) {
                 $this->assertEquals($params['header'], $options['header']);
             }
-            return $params['response'] ?? null;
+            return $params['response'] ?? '';
         }));
     }
 

--- a/tests/CrowdinApiClient/Api/AbstractTestApi.php
+++ b/tests/CrowdinApiClient/Api/AbstractTestApi.php
@@ -44,10 +44,10 @@ abstract class AbstractTestApi extends TestCase
             }
 
             if (isset($params['body'])) {
-                $this->assertEquals($params['body'], $params['body']);
+                $this->assertEquals($params['body'], $options['body']);
             }
             if (isset($params['header'])) {
-                $this->assertEquals($params['header'], $params['header']);
+                $this->assertEquals($params['header'], $options['header']);
             }
             return $params['response'] ?? null;
         }));

--- a/tests/CrowdinApiClient/Api/BranchApiTest.php
+++ b/tests/CrowdinApiClient/Api/BranchApiTest.php
@@ -98,7 +98,7 @@ class BranchApiTest extends AbstractTestApi
         $this->mockRequest([
             'path' => '/projects/2/branches',
             'method' => 'post',
-            'body' => $params,
+            'body' => json_encode($params),
             'response' => '{
                   "data": {
                     "id": 34,

--- a/tests/CrowdinApiClient/Api/BundleApiTest.php
+++ b/tests/CrowdinApiClient/Api/BundleApiTest.php
@@ -96,7 +96,7 @@ class BundleApiTest extends AbstractTestApi
         $this->mockRequest([
             'path' => '/projects/2/bundles',
             'method' => 'post',
-            'body' => $params,
+            'body' => json_encode($params),
             'response' => '{
                   "data": {
                     "id": 34,
@@ -247,7 +247,7 @@ class BundleApiTest extends AbstractTestApi
         $this->mockRequest([
             'path' => '/projects/1/bundles/2/exports',
             'method' => 'post',
-            'body' => $params,
+            'body' => json_encode($params),
             'response' => '{
               "data": {
                 "identifier": "50fb3506-4127-4ba8-8296-f97dc7e3e0c3",

--- a/tests/CrowdinApiClient/Api/DirectoryApiTest.php
+++ b/tests/CrowdinApiClient/Api/DirectoryApiTest.php
@@ -99,7 +99,7 @@ class DirectoryApiTest extends AbstractTestApi
         $this->mockRequest([
             'path' => '/projects/2/directories',
             'method' => 'post',
-            'body' => $params,
+            'body' => json_encode($params),
             'response' => '{
                   "data": {
                     "id": 34,

--- a/tests/CrowdinApiClient/Api/DistributionApiTest.php
+++ b/tests/CrowdinApiClient/Api/DistributionApiTest.php
@@ -62,7 +62,7 @@ class DistributionApiTest extends AbstractTestApi
         $this->mockRequest([
             'path' => '/projects/2/distributions',
             'method' => 'post',
-            'body' => $params,
+            'body' => json_encode($params),
             'response' => '{
               "data": {
                 "hash": "e-4326c06be14321dd967b161a",

--- a/tests/CrowdinApiClient/Api/Enterprise/AbstractTestApi.php
+++ b/tests/CrowdinApiClient/Api/Enterprise/AbstractTestApi.php
@@ -50,7 +50,7 @@ abstract class AbstractTestApi extends TestCase
             if (isset($params['header'])) {
                 $this->assertEquals($params['header'], $options['header']);
             }
-            return $params['response'] ?? null;
+            return $params['response'] ?? '';
         }));
     }
 

--- a/tests/CrowdinApiClient/Api/Enterprise/AbstractTestApi.php
+++ b/tests/CrowdinApiClient/Api/Enterprise/AbstractTestApi.php
@@ -45,10 +45,10 @@ abstract class AbstractTestApi extends TestCase
             }
 
             if (isset($params['body'])) {
-                $this->assertEquals($params['body'], $params['body']);
+                $this->assertEquals($params['body'], $options['body']);
             }
             if (isset($params['header'])) {
-                $this->assertEquals($params['header'], $params['header']);
+                $this->assertEquals($params['header'], $options['header']);
             }
             return $params['response'] ?? null;
         }));

--- a/tests/CrowdinApiClient/Api/Enterprise/FileApiTest.php
+++ b/tests/CrowdinApiClient/Api/Enterprise/FileApiTest.php
@@ -20,7 +20,7 @@ class FileApiTest extends AbstractTestApi
         $this->mockRequest([
             'path' => '/projects/2/strings/reviewed-builds',
             'method' => 'post',
-            'body' => $params,
+            'body' => json_encode($params),
             'response' => '{
                   "data": {
                     "id": 44,

--- a/tests/CrowdinApiClient/Api/Enterprise/GlossaryApiTest.php
+++ b/tests/CrowdinApiClient/Api/Enterprise/GlossaryApiTest.php
@@ -60,7 +60,7 @@ class GlossaryApiTest extends AbstractTestApi
         $this->mockRequest([
             'path' => '/glossaries',
             'method' => 'post',
-            'body' => $params,
+            'body' => json_encode($params),
             'response' => '{
                   "data": {
                     "id": 2,
@@ -140,13 +140,15 @@ class GlossaryApiTest extends AbstractTestApi
 
     public function testExport()
     {
+        $params = [
+            'format' => 'tbx',
+            'exportFields' => ['term', 'description', 'partOfSpeech'],
+        ];
+
         $this->mockRequest([
             'path' => '/glossaries/2/exports',
             'method' => 'post',
-            'body' => [
-                'format' => 'tbx',
-                'exportFields' => [ 'term', 'description', 'partOfSpeech' ],
-            ],
+            'body' => json_encode($params),
             'response' => '{
                   "data": {
                     "identifier": "5ed2ce93-6d47-4402-9e66-516ca835cb20",

--- a/tests/CrowdinApiClient/Api/Enterprise/MachineTranslationEngineApiTest.php
+++ b/tests/CrowdinApiClient/Api/Enterprise/MachineTranslationEngineApiTest.php
@@ -24,7 +24,7 @@ class MachineTranslationEngineApiTest extends AbstractTestApi
         $this->mockRequest([
             'path' => '/mts',
             'method' => 'post',
-            'body' => $params,
+            'body' => json_encode($params),
             'response' => '{
               "data": {
                 "id": 2,

--- a/tests/CrowdinApiClient/Api/Enterprise/ProjectApiTest.php
+++ b/tests/CrowdinApiClient/Api/Enterprise/ProjectApiTest.php
@@ -73,7 +73,7 @@ class ProjectApiTest extends AbstractTestApi
         $this->mockRequest([
             'path' => '/projects',
             'method' => 'post',
-            'body' => $params,
+            'body' => json_encode($params),
             'response' => '{
                   "data": {
                     "id": 8,

--- a/tests/CrowdinApiClient/Api/Enterprise/StringTranslationApiTest.php
+++ b/tests/CrowdinApiClient/Api/Enterprise/StringTranslationApiTest.php
@@ -139,7 +139,7 @@ class StringTranslationApiTest extends AbstractTestApi
         $this->mockRequest([
             'path' => '/projects/2/translations',
             'method' => 'post',
-            'body' => $params,
+            'body' => json_encode($params),
             'response' => '{
                   "data": {
                     "id": 190695,
@@ -204,7 +204,7 @@ class StringTranslationApiTest extends AbstractTestApi
 
         $this->mockRequest([
             'path' => '/projects/2/approvals',
-            'body' => $params,
+            'body' => json_encode($params),
             'method' => 'post',
             'response' => '{
                   "data": {
@@ -301,7 +301,7 @@ class StringTranslationApiTest extends AbstractTestApi
         $this->mockRequest([
             'path' => '/projects/2/votes',
             'method' => 'post',
-            'body' => $params,
+            'body' => json_encode($params),
             'response' => '{
               "data": {
                 "id": 6643,

--- a/tests/CrowdinApiClient/Api/Enterprise/TaskApiTest.php
+++ b/tests/CrowdinApiClient/Api/Enterprise/TaskApiTest.php
@@ -99,7 +99,7 @@ class TaskApiTest extends AbstractTestApi
         $this->mockRequest([
             'path' => '/projects/2/tasks',
             'method' => 'post',
-            'body' => $params,
+            'body' => json_encode($params),
             'response' => '{
                   "data": {
                     "id": 2,

--- a/tests/CrowdinApiClient/Api/Enterprise/TeamApiTest.php
+++ b/tests/CrowdinApiClient/Api/Enterprise/TeamApiTest.php
@@ -51,7 +51,7 @@ class TeamApiTest extends AbstractTestApi
         $this->mockRequest([
             'path' => '/teams',
             'method' => 'post',
-            'body' => $params,
+            'body' => json_encode($params),
             'response' => '{
                   "data": {
                     "id": 2,
@@ -120,7 +120,7 @@ class TeamApiTest extends AbstractTestApi
         $this->mockRequest([
             'path' => '/projects/2/teams',
             'method' => 'post',
-            'body' => $params,
+            'body' => json_encode($params),
             'response' => '
                 {
                     "data": {

--- a/tests/CrowdinApiClient/Api/Enterprise/TranslationApiTest.php
+++ b/tests/CrowdinApiClient/Api/Enterprise/TranslationApiTest.php
@@ -24,7 +24,7 @@ class TranslationApiTest extends AbstractTestApi
         $this->mockRequest([
             'path' => '/projects/2/pre-translations',
             'method' => 'post',
-            'body' => $params,
+            'body' => json_encode($params),
             'response' => '{
                   "data": {
                     "identifier": "9e7de270-4f83-41cb-b606-2f90631f26e2",

--- a/tests/CrowdinApiClient/Api/Enterprise/UserApiTest.php
+++ b/tests/CrowdinApiClient/Api/Enterprise/UserApiTest.php
@@ -23,7 +23,7 @@ class UserApiTest extends AbstractTestApi
         $this->mockRequest([
             'path' => '/projects/1/members',
             'method' => 'post',
-            'body' => $params,
+            'body' => json_encode($params),
             'response' => '{
             "skipped": [],
             "added": [
@@ -133,7 +133,7 @@ class UserApiTest extends AbstractTestApi
         $this->mockRequest([
             'path' => '/projects/1/members/1',
             'method' => 'put',
-            'body' => $params,
+            'body' => json_encode($params),
             'response' => '{
               "data": {
                 "id": 1,

--- a/tests/CrowdinApiClient/Api/FileApiTest.php
+++ b/tests/CrowdinApiClient/Api/FileApiTest.php
@@ -281,7 +281,7 @@ class FileApiTest extends AbstractTestApi
         $this->mockRequest([
             'path' => '/projects/2/files',
             'method' => 'post',
-            'body' => $params,
+            'body' => json_encode($params),
             'response' => '{
               "data": {
                 "id": 44,

--- a/tests/CrowdinApiClient/Api/GlossaryApiTest.php
+++ b/tests/CrowdinApiClient/Api/GlossaryApiTest.php
@@ -80,7 +80,7 @@ class GlossaryApiTest extends AbstractTestApi
                 }'
         ]);
 
-        $glossary = $this->crowdin->glossary->create(['name', 'Be My Eyes iOS\'s Glossary']);
+        $glossary = $this->crowdin->glossary->create(['name' => 'Be My Eyes iOS\'s Glossary']);
         $this->assertInstanceOf(Glossary::class, $glossary);
         $this->assertEquals(2, $glossary->getId());
     }

--- a/tests/CrowdinApiClient/Api/GlossaryApiTest.php
+++ b/tests/CrowdinApiClient/Api/GlossaryApiTest.php
@@ -61,7 +61,7 @@ class GlossaryApiTest extends AbstractTestApi
         $this->mockRequest([
             'path' => '/glossaries',
             'method' => 'post',
-            'body' => $params,
+            'body' => json_encode($params),
             'response' => '{
                   "data": {
                     "id": 2,
@@ -141,13 +141,15 @@ class GlossaryApiTest extends AbstractTestApi
 
     public function testExport()
     {
+        $params = [
+            'format' => 'tbx',
+            'exportFields' => ['term', 'description', 'partOfSpeech'],
+        ];
+
         $this->mockRequest([
             'path' => '/glossaries/2/exports',
             'method' => 'post',
-            'body' => [
-                'format' => 'tbx',
-                'exportFields' => [ 'term', 'description', 'partOfSpeech' ],
-            ],
+            'body' => json_encode($params),
             'response' => '{
                   "data": {
                     "identifier": "5ed2ce93-6d47-4402-9e66-516ca835cb20",
@@ -190,10 +192,11 @@ class GlossaryApiTest extends AbstractTestApi
         $params = [
             'storageId' => 2
         ];
+
         $this->mockRequest([
             'path' => '/glossaries/2/imports',
             'method' => 'post',
-            'body' => $params,
+            'body' => json_encode($params),
             'response' => '{
                   "data": {
                     "identifier": "c050fba2-200e-4ce1-8de4-f7ba8eb58732",
@@ -308,7 +311,7 @@ class GlossaryApiTest extends AbstractTestApi
         $this->mockRequest([
             'path' => '/glossaries/2/terms',
             'method' => 'post',
-            'body' => $data,
+            'body' => json_encode($data),
             'response' => '{
               "data": {
                 "id": 2,

--- a/tests/CrowdinApiClient/Api/LabelApiTest.php
+++ b/tests/CrowdinApiClient/Api/LabelApiTest.php
@@ -79,7 +79,7 @@ class LabelApiTest extends AbstractTestApi
         $this->mockRequest([
             'path' => '/projects/2/labels',
             'method' => 'post',
-            'body' => $params,
+            'body' => json_encode($params),
             'response' => '{
                   "data": {
                     "id": 34,

--- a/tests/CrowdinApiClient/Api/MachineTranslationEngineApiTest.php
+++ b/tests/CrowdinApiClient/Api/MachineTranslationEngineApiTest.php
@@ -87,7 +87,7 @@ class MachineTranslationEngineApiTest extends AbstractTestApi
         $this->mockRequest([
             'path' => '/mts/2/translations',
             'method' => 'post',
-            'body' => $params,
+            'body' => json_encode($params),
             'response' => '{
               "data": {
                 "sourceLanguageId": "en",

--- a/tests/CrowdinApiClient/Api/ProjectApiTest.php
+++ b/tests/CrowdinApiClient/Api/ProjectApiTest.php
@@ -71,7 +71,7 @@ class ProjectApiTest extends AbstractTestApi
         $this->mockRequest([
             'path' => '/projects',
             'method' => 'post',
-            'body' => $params,
+            'body' => json_encode($params),
             'response' => '{
                   "data": {
                     "id": 8,

--- a/tests/CrowdinApiClient/Api/ScreenshotApiTest.php
+++ b/tests/CrowdinApiClient/Api/ScreenshotApiTest.php
@@ -72,7 +72,7 @@ class ScreenshotApiTest extends AbstractTestApi
         $this->mockRequest([
             'path' => '/projects/2/screenshots',
             'method' => 'post',
-            'body' => $params,
+            'body' => json_encode($params),
             'response' => '{
                   "data": {
                     "id": 2,
@@ -193,7 +193,7 @@ class ScreenshotApiTest extends AbstractTestApi
         $this->mockRequest([
             'path' => '/projects/2/screenshots/2',
             'method' => 'put',
-            'body' => $params,
+            'body' => json_encode($params),
             'response' => '{
               "data": {
                 "id": 2,
@@ -255,7 +255,7 @@ class ScreenshotApiTest extends AbstractTestApi
         $this->mockRequest([
             'path' => '/projects/2/screenshots/2/tags',
             'method' => 'post',
-            'body' => $params,
+            'body' => json_encode($params),
             'response' => '{
                   "data": {
                     "id": 98,
@@ -401,7 +401,7 @@ class ScreenshotApiTest extends AbstractTestApi
         $this->mockRequest([
             'path' => '/projects/2/screenshots/2/tags',
             'method' => 'put',
-            'body' => $params
+            'body' => json_encode($params)
         ]);
 
         $this->crowdin->screenshot->replaceTags(2, 2, $params);

--- a/tests/CrowdinApiClient/Api/SourceStringApiTest.php
+++ b/tests/CrowdinApiClient/Api/SourceStringApiTest.php
@@ -137,7 +137,7 @@ class SourceStringApiTest extends AbstractTestApi
                     "updatedAt": "2019-09-20T13:24:01+00:00"
                   }
                 }',
-            'body' => $params
+            'body' => json_encode($params)
         ]);
 
         $sourceString = $this->crowdin->sourceString->create(2, $params);

--- a/tests/CrowdinApiClient/Api/StringCommentApiTest.php
+++ b/tests/CrowdinApiClient/Api/StringCommentApiTest.php
@@ -78,7 +78,7 @@ class StringCommentApiTest extends AbstractTestApi
         $this->mockRequest([
             'path' => '/projects/1/comments',
             'method' => 'post',
-            'body' => $params,
+            'body' => json_encode($params),
             'response' => '{
               "data": {
                 "id": 2,

--- a/tests/CrowdinApiClient/Api/StringTranslationApiTest.php
+++ b/tests/CrowdinApiClient/Api/StringTranslationApiTest.php
@@ -138,7 +138,7 @@ class StringTranslationApiTest extends AbstractTestApi
         $this->mockRequest([
             'path' => '/projects/2/translations',
             'method' => 'post',
-            'body' => $params,
+            'body' => json_encode($params),
             'response' => '{
                   "data": {
                     "id": 190695,

--- a/tests/CrowdinApiClient/Api/StringTranslationApiTest.php
+++ b/tests/CrowdinApiClient/Api/StringTranslationApiTest.php
@@ -160,15 +160,9 @@ class StringTranslationApiTest extends AbstractTestApi
 
     public function testDeleteStringTranslations()
     {
-        $params = [
-            'stringId' => 1,
-            'languageId' => 'en'
-        ];
-
         $this->mockRequest([
-            'path' => '/projects/1/translations',
+            'path' => '/projects/1/translations?stringId=1&languageId=en',
             'method' => 'delete',
-            'body' => $params,
             'response' => '',
         ]);
 

--- a/tests/CrowdinApiClient/Api/TaskApiTest.php
+++ b/tests/CrowdinApiClient/Api/TaskApiTest.php
@@ -102,7 +102,7 @@ class TaskApiTest extends AbstractTestApi
         $this->mockRequest([
             'path' => '/projects/2/tasks',
             'method' => 'post',
-            'body' => $params,
+            'body' => json_encode($params),
             'response' => '{
               "data": {
                 "id": 2,

--- a/tests/CrowdinApiClient/Api/TranslationApiTest.php
+++ b/tests/CrowdinApiClient/Api/TranslationApiTest.php
@@ -23,7 +23,7 @@ class TranslationApiTest extends AbstractTestApi
         $this->mockRequest([
             'path' => '/projects/2/pre-translations',
             'method' => 'post',
-            'body' => $params,
+            'body' => json_encode($params),
             'response' => '{
                   "data": {
                     "identifier": "9e7de270-4f83-41cb-b606-2f90631f26e2",

--- a/tests/CrowdinApiClient/Api/TranslationMemoryApiTest.php
+++ b/tests/CrowdinApiClient/Api/TranslationMemoryApiTest.php
@@ -62,7 +62,7 @@ class TranslationMemoryApiTest extends AbstractTestApi
         $this->mockRequest([
             'path' => '/tms',
             'method' => 'post',
-            'body' => $params,
+            'body' => json_encode($params),
             'response' => '{
               "data": {
                 "id": 4,
@@ -161,7 +161,7 @@ class TranslationMemoryApiTest extends AbstractTestApi
         $this->mockRequest([
             'path' => '/tms/4/exports',
             'method' => 'post',
-            'body' => $params,
+            'body' => json_encode($params),
             'response' => '{
               "data": {
                 "identifier": "50fb3506-4127-4ba8-8296-f97dc7e3e0c3",

--- a/tests/CrowdinApiClient/Api/TranslationMemoryApiTest.php
+++ b/tests/CrowdinApiClient/Api/TranslationMemoryApiTest.php
@@ -182,7 +182,7 @@ class TranslationMemoryApiTest extends AbstractTestApi
             }'
         ]);
 
-        $export = $this->crowdin->translationMemory->export(4);
+        $export = $this->crowdin->translationMemory->export(4, $params);
         $this->assertInstanceOf(TranslationMemoryExport::class, $export);
         $this->assertEquals('50fb3506-4127-4ba8-8296-f97dc7e3e0c3', $export->getIdentifier());
     }
@@ -215,7 +215,7 @@ class TranslationMemoryApiTest extends AbstractTestApi
 
     public function testImport()
     {
-        $params = [
+        $expected_body = [
             'storageId' => 0,
             'firstLineContainsHeader' => false,
             'scheme' =>
@@ -226,11 +226,17 @@ class TranslationMemoryApiTest extends AbstractTestApi
                     'phraseUk' => 4,
                 ],
         ];
+        $params = [
+            'phraseEn' => 0,
+            'phraseDe' => 1,
+            'phrasePl' => 2,
+            'phraseUk' => 4,
+        ];
 
         $this->mockRequest([
             'path' => '/tms/4/imports',
             'method' => 'post',
-            'body' => $params,
+            'body' => json_encode($expected_body),
             'response' => '{
                       "data": {
                         "identifier": "b5215a34-1305-4b21-8054-fc2eb252842f",
@@ -256,7 +262,7 @@ class TranslationMemoryApiTest extends AbstractTestApi
                     }'
         ]);
 
-        $translationMemoryImport = $this->crowdin->translationMemory->import(4, 0, $params);
+        $translationMemoryImport = $this->crowdin->translationMemory->import(4, 0, false, $params);
         $this->assertInstanceOf(TranslationMemoryImport::class, $translationMemoryImport);
         $this->assertEquals('b5215a34-1305-4b21-8054-fc2eb252842f', $translationMemoryImport->getIdentifier());
     }

--- a/tests/CrowdinApiClient/Api/WebhookApiTest.php
+++ b/tests/CrowdinApiClient/Api/WebhookApiTest.php
@@ -79,7 +79,7 @@ class WebhookApiTest extends AbstractTestApi
         $this->mockRequest([
             'path' => '/projects/2/webhooks',
             'method' => 'post',
-            'body' => $params,
+            'body' => json_encode($params),
             'response' => '{
               "data": {
                 "id": 4,


### PR DESCRIPTION
This addresses the issues in `AbstractTestApi::mockRequest` assertions and resolves the missed issues with many unit tests. Primarily the tests themselves have issues where they pass in an array but `mockRequest` asserts against a json string. Additionally when a `$params['response']` was unset, `AbstractTestApi::mockRequest` would return `null` which was causing `PHP Notices` that the GitHub Actions configuration was hiding.

There was one issue with `AbstractApi::_delete` that was detected with the fixed assertions where `$params` was being passed to `Crowdin::apiRequest` without being wrapped into a request `$options`.

Fixes #149