### PR TITLE
fix: Add missing phpdoc `run` command

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -21,7 +21,7 @@ jobs:
 
       - name: Generate documentation
         run: |
-          docker run --rm -v $(pwd):/data phpdoc/phpdoc:3 -d src -t .phpdoc/build
+          docker run --rm -v $(pwd):/data phpdoc/phpdoc:3 run -d src -t .phpdoc/build
 
       - name: Deploy 🚀
         uses: JamesIves/github-pages-deploy-action@v4


### PR DESCRIPTION
Tested new command locally

```shell
$ docker run --rm -v $(pwd):/data phpdoc/phpdoc:3 run -d src -t .phpdoc/build
phpDocumentor 3.4.1-dev-master+8b2bec0

Parsing files

   1/120 [>---------------------------]   0%
  12/120 [==>-------------------------]  10%
  24/120 [=====>----------------------]  20%
  36/120 [========>-------------------]  30%
  48/120 [===========>----------------]  40%
  60/120 [==============>-------------]  50%
  72/120 [================>-----------]  60%
  84/120 [===================>--------]  70%
  96/120 [======================>-----]  80%
 108/120 [=========================>--]  90%
 120/120 [============================] 100%
Applying transformations (can take a while)

All done in 7 seconds!
```

Fixes #155 