### PR TITLE
feat: Add Projects `qaChecksIgnorableCategories` support

### DIFF
--- a/src/CrowdinApiClient/Model/Project.php
+++ b/src/CrowdinApiClient/Model/Project.php
@@ -208,6 +208,11 @@ class Project extends BaseModel
     protected $qaCheckCategories = [];
 
     /**
+     * @var array
+     */
+    protected $qaChecksIgnorableCategories = [];
+
+    /**
      * @var int[]
      */
     protected $customQaCheckIds = [];
@@ -280,6 +285,7 @@ class Project extends BaseModel
         $this->inContextPseudoLanguage = (array)$this->getDataProperty('inContextPseudoLanguage');
         $this->qaCheckIsActive = (bool)$this->getDataProperty('qaCheckIsActive');
         $this->qaCheckCategories = (array)$this->getDataProperty('qaCheckCategories');
+        $this->qaChecksIgnorableCategories = (array)$this->getDataProperty('qaChecksIgnorableCategories');
         $this->customQaCheckIds = (array)$this->getDataProperty('customQaCheckIds');
         $this->languageMapping = (array)$this->getDataProperty('languageMapping');
         $this->glossaryAccess = (bool)$this->getDataProperty('glossaryAccess');
@@ -867,6 +873,22 @@ class Project extends BaseModel
     public function setQaCheckCategories(array $qaCheckCategories): void
     {
         $this->qaCheckCategories = $qaCheckCategories;
+    }
+
+    /**
+     * @return array
+     */
+    public function getQaChecksIgnorableCategories(): array
+    {
+        return $this->qaChecksIgnorableCategories;
+    }
+
+    /**
+     * @param array $qaChecksIgnorableCategories
+     */
+    public function setQaChecksIgnorableCategories(array $qaChecksIgnorableCategories): void
+    {
+        $this->qaChecksIgnorableCategories = $qaChecksIgnorableCategories;
     }
 
     /**

--- a/tests/CrowdinApiClient/Api/ProjectApiTest.php
+++ b/tests/CrowdinApiClient/Api/ProjectApiTest.php
@@ -66,6 +66,39 @@ class ProjectApiTest extends AbstractTestApi
             'languageAccessPolicy' => 'moderate',
             'cname' => 'my-custom-domain.crowdin.com',
             'description' => 'Articles and tutorials',
+            'qaCheckIsActive' => true,
+            'qaCheckCategories' =>
+                [
+                    'empty' => true,
+                    'size' => true,
+                    'tags' => true,
+                    'spaces' => true,
+                    'variables' => true,
+                    'punctuation' => true,
+                    'symbolRegister' => true,
+                    'specialSymbols' => true,
+                    'wrongTranslation' => true,
+                    'spellcheck' => true,
+                    'icu' => true,
+                ],
+            'qaChecksIgnorableCategories' =>
+                [
+                    'empty' => false,
+                    'size' => true,
+                    'tags' => true,
+                    'spaces' => true,
+                    'variables' => true,
+                    'punctuation' => true,
+                    'symbolRegister' => true,
+                    'specialSymbols' => true,
+                    'wrongTranslation' => true,
+                    'spellcheck' => true,
+                    'icu' => false,
+                    'terms' => true,
+                    'duplicate' => false,
+                    'ftl' => false,
+                    'android' => true,
+                ],
         ];
 
         $this->mockRequest([
@@ -114,6 +147,37 @@ class ProjectApiTest extends AbstractTestApi
                       "translatorNewStrings": "false",
                       "managerNewStrings": "false",
                       "managerLanguageCompleted": "false"
+                    },
+                    "qaCheckIsActive": true,
+                    "qaCheckCategories": {
+                      "empty": "true",
+                      "size": "true",
+                      "tags": "true",
+                      "spaces": "true",
+                      "variables": "true",
+                      "punctuation": "true",
+                      "symbolRegister": "true",
+                      "specialSymbols": "true",
+                      "wrongTranslation": "true",
+                      "spellcheck": "true",
+                      "icu": "true"
+                    },
+                    "qaChecksIgnorableCategories": {
+                      "empty": "false",
+                      "size": "true",
+                      "tags": "true",
+                      "spaces": "true",
+                      "variables": "true",
+                      "punctuation": "true",
+                      "symbolRegister": "true",
+                      "specialSymbols": "true",
+                      "wrongTranslation": "true",
+                      "spellcheck": "true",
+                      "icu": "false",
+                      "terms": "true",
+                      "duplicate": "false",
+                      "ftl": "false",
+                      "android": "true"
                     },
                     "createdAt": "2019-09-20T11:34:40+00:00",
                     "updatedAt": "2019-09-20T11:34:40+00:00"
@@ -173,6 +237,37 @@ class ProjectApiTest extends AbstractTestApi
                               "managerNewStrings": "false",
                               "managerLanguageCompleted": "false"
                             },
+                            "qaCheckIsActive": true,
+                            "qaCheckCategories": {
+                              "empty": "true",
+                              "size": "true",
+                              "tags": "true",
+                              "spaces": "true",
+                              "variables": "true",
+                              "punctuation": "true",
+                              "symbolRegister": "true",
+                              "specialSymbols": "true",
+                              "wrongTranslation": "true",
+                              "spellcheck": "true",
+                              "icu": "true"
+                            },
+                            "qaChecksIgnorableCategories": {
+                              "empty": "false",
+                              "size": "true",
+                              "tags": "true",
+                              "spaces": "true",
+                              "variables": "true",
+                              "punctuation": "true",
+                              "symbolRegister": "true",
+                              "specialSymbols": "true",
+                              "wrongTranslation": "true",
+                              "spellcheck": "true",
+                              "icu": "false",
+                              "terms": "true",
+                              "duplicate": "false",
+                              "ftl": "false",
+                              "android": "true"
+                            },
                             "createdAt": "2019-09-20T11:34:40+00:00",
                             "updatedAt": "2019-09-20T11:34:40+00:00"
                     }
@@ -225,6 +320,37 @@ class ProjectApiTest extends AbstractTestApi
                               "translatorNewStrings": "false",
                               "managerNewStrings": "false",
                               "managerLanguageCompleted": "false"
+                            },
+                            "qaCheckIsActive": true,
+                            "qaCheckCategories": {
+                              "empty": "true",
+                              "size": "true",
+                              "tags": "true",
+                              "spaces": "true",
+                              "variables": "true",
+                              "punctuation": "true",
+                              "symbolRegister": "true",
+                              "specialSymbols": "true",
+                              "wrongTranslation": "true",
+                              "spellcheck": "true",
+                              "icu": "true"
+                            },
+                            "qaChecksIgnorableCategories": {
+                              "empty": "false",
+                              "size": "true",
+                              "tags": "true",
+                              "spaces": "true",
+                              "variables": "true",
+                              "punctuation": "true",
+                              "symbolRegister": "true",
+                              "specialSymbols": "true",
+                              "wrongTranslation": "true",
+                              "spellcheck": "true",
+                              "icu": "false",
+                              "terms": "true",
+                              "duplicate": "false",
+                              "ftl": "false",
+                              "android": "true"
                             },
                             "createdAt": "2019-09-20T11:34:40+00:00",
                             "updatedAt": "2019-09-20T11:34:40+00:00"

--- a/tests/CrowdinApiClient/Model/ProjectTest.php
+++ b/tests/CrowdinApiClient/Model/ProjectTest.php
@@ -87,6 +87,24 @@ class ProjectTest extends TestCase
                 'spellcheck' => true,
                 'icu' => true,
             ],
+        'qaChecksIgnorableCategories' =>
+            [
+                'empty' => false,
+                'size' => true,
+                'tags' => true,
+                'spaces' => true,
+                'variables' => true,
+                'punctuation' => true,
+                'symbolRegister' => true,
+                'specialSymbols' => true,
+                'wrongTranslation' => true,
+                'spellcheck' => true,
+                'icu' => false,
+                'terms' => true,
+                'duplicate' => false,
+                'ftl' => false,
+                'android' => true,
+            ],
         'customQaCheckIds' =>
             [
                 0 => '1',
@@ -191,6 +209,7 @@ class ProjectTest extends TestCase
         $this->assertEquals($this->data['inContextPseudoLanguageId'], $this->project->getInContextPseudoLanguageId());
         $this->assertEquals($this->data['qaCheckIsActive'], $this->project->isQaCheckIsActive());
         $this->assertEquals($this->data['qaCheckCategories'], $this->project->getQaCheckCategories());
+        $this->assertEquals($this->data['qaChecksIgnorableCategories'], $this->project->getQaChecksIgnorableCategories());
         $this->assertEquals($this->data['customQaCheckIds'], $this->project->getCustomQaCheckIds());
         $this->assertEquals($this->data['languageMapping'], $this->project->getLanguageMapping());
         $this->assertEquals($this->data['isSuspended'], $this->project->isSuspended());


### PR DESCRIPTION
Adds `Project:: qaChecksIgnorableCategories` property. As the API calls themselves use unstructured array, I've added the expected array and json to `ProjectTest` & `ProjectApiTest` to provide expected example usage.

Closes #123 