### PR TITLE
feat: List Language Translations API: support new parameters

### DIFF
--- a/src/CrowdinApiClient/Api/StringTranslationApi.php
+++ b/src/CrowdinApiClient/Api/StringTranslationApi.php
@@ -93,8 +93,14 @@ class StringTranslationApi extends AbstractApi
      * @param int $projectId
      * @param string $languageId
      * @param array $params
+     * string $params[orderBy]<br>
      * string $params[stringIds]<br>
+     * string $params[labelIds]<br>
      * int $params[fileId]<br>
+     * int $params[branchId]<br>
+     * int $params[directoryId]<br>
+     * int $params[approvedOnly]<br>
+     * string $params[croql]<br>
      * int $params[denormalizePlaceholders]<br>
      * int $params[limit]<br>
      * int $params[offset]


### PR DESCRIPTION
Updates the `StringTranslationApi` doctags to document the new parameters. No other code changes were found to be needed as the parameters are not in the response objects.

Closes #175