### PR TITLE
fix: php 8.4 warnings

### DIFF
--- a/src/CrowdinApiClient/Crowdin.php
+++ b/src/CrowdinApiClient/Crowdin.php
@@ -185,7 +185,7 @@ class Crowdin
      * @param array $options
      * @return mixed
      */
-    public function apiRequest(string $method, string $path, ResponseDecoratorInterface $decorator = null, array $options = [])
+    public function apiRequest(string $method, string $path, ?ResponseDecoratorInterface $decorator = null, array $options = [])
     {
         $response = $this->request($method, $this->getFullUrl($path), $options);
 

--- a/src/CrowdinApiClient/Http/Client/GuzzleHttpClient.php
+++ b/src/CrowdinApiClient/Http/Client/GuzzleHttpClient.php
@@ -50,7 +50,7 @@ class GuzzleHttpClient implements CrowdinHttpClientInterface
      *
      * @param Client|null $client GuzzleHttp Client
      */
-    public function __construct(Client $client = null)
+    public function __construct(?Client $client = null)
     {
         $this->client = $client ?: new Client();
     }


### PR DESCRIPTION
PHP 8.4 deprecates implicitly allowing nullable param types. This fixes the issues in this package.


Closes: https://github.com/crowdin/crowdin-api-client-php/issues/212
