### PR TITLE
feat: Add defaultTmId and defaultGlossaryId to Project API

### DIFF
--- a/src/CrowdinApiClient/Api/ProjectApi.php
+++ b/src/CrowdinApiClient/Api/ProjectApi.php
@@ -69,7 +69,9 @@ class ProjectApi extends AbstractApi
      * boolean $data[skipUntranslatedStrings]<br>
      * boolean $data[skipUntranslatedFiles]<br>
      * integer $data[exportWithMinApprovalsCount]<br>
-     * integer $data[exportApprovedOnly]
+     * integer $data[exportApprovedOnly]<br>
+     * integer $data[defaultTmId]<br>
+     * integer $data[defaultGlossaryId]
      * @return Project|null
      */
     public function create(array $data): ?Project

--- a/src/CrowdinApiClient/Model/Project.php
+++ b/src/CrowdinApiClient/Model/Project.php
@@ -242,6 +242,16 @@ class Project extends BaseModel
      */
     protected $notificationSettings = [];
 
+    /**
+     * @var integer
+     */
+    protected $defaultTmId;
+
+    /**
+     * @var integer
+     */
+    protected $defaultGlossaryId;
+
     public function __construct(array $data = [])
     {
         parent::__construct($data);
@@ -293,6 +303,8 @@ class Project extends BaseModel
         $this->normalizePlaceholder = (bool)$this->getDataProperty('normalizePlaceholder');
         $this->saveMetaInfoInSource = (bool)$this->getDataProperty('saveMetaInfoInSource');
         $this->notificationSettings = (array)$this->getDataProperty('notificationSettings');
+        $this->defaultTmId = (integer)$this->getDataProperty('defaultTmId');
+        $this->defaultGlossaryId = (integer)$this->getDataProperty('defaultGlossaryId');
     }
 
     /**
@@ -1033,5 +1045,37 @@ class Project extends BaseModel
     public function setNotificationSettings(array $notificationSettings): void
     {
         $this->notificationSettings = $notificationSettings;
+    }
+
+    /**
+     * @return int|null
+     */
+    public function getDefaultTmId(): ?int
+    {
+        return $this->defaultTmId;
+    }
+
+    /**
+     * @param int|null $defaultTmId
+     */
+    public function setDefaultTmId(?int $defaultTmId): void
+    {
+        $this->defaultTmId = $defaultTmId;
+    }
+
+    /**
+     * @return int|null
+     */
+    public function getDefaultGlossaryId(): ?int
+    {
+        return $this->defaultGlossaryId;
+    }
+
+    /**
+     * @param int|null $defaultGlossaryId
+     */
+    public function setDefaultGlossaryId(?int $defaultGlossaryId): void
+    {
+        $this->defaultGlossaryId = $defaultGlossaryId;
     }
 }

--- a/tests/CrowdinApiClient/Model/ProjectTest.php
+++ b/tests/CrowdinApiClient/Model/ProjectTest.php
@@ -141,6 +141,8 @@ class ProjectTest extends TestCase
         ],
         'joinPolicy' => null,
         'visibility' => null,
+        'defaultTmId' => 10,
+        'defaultGlossaryId' => 20,
     ];
 
     public function testLoadData()
@@ -214,5 +216,7 @@ class ProjectTest extends TestCase
         $this->assertEquals($this->data['normalizePlaceholder'], $this->project->isNormalizePlaceholder());
         $this->assertEquals($this->data['saveMetaInfoInSource'], $this->project->isSaveMetaInfoInSource());
         $this->assertEquals($this->data['notificationSettings'], $this->project->getNotificationSettings());
+        $this->assertEquals($this->data['defaultTmId'], $this->project->getDefaultTmId());
+        $this->assertEquals($this->data['defaultGlossaryId'], $this->project->getDefaultGlossaryId());
     }
 }


### PR DESCRIPTION
Adds `defaultTmId` and `defaultGlossaryId` properties to the Project model, updates API documentation, and adds test coverage.

Closes #186