### PR TITLE
feat: Add Translation Alignment and TM Concordance API endpoints

### DIFF
--- a/src/CrowdinApiClient/Api/TranslationApi.php
+++ b/src/CrowdinApiClient/Api/TranslationApi.php
@@ -7,6 +7,7 @@ use CrowdinApiClient\Model\DownloadFile;
 use CrowdinApiClient\Model\DownloadFileTranslation;
 use CrowdinApiClient\Model\PreTranslation;
 use CrowdinApiClient\Model\PreTranslationReport;
+use CrowdinApiClient\Model\TranslationAlignment;
 use CrowdinApiClient\Model\TranslationProjectBuild;
 use CrowdinApiClient\Model\TranslationProjectDirectory;
 use CrowdinApiClient\ModelCollection;
@@ -268,5 +269,24 @@ class TranslationApi extends AbstractApi
     {
         $path = sprintf('projects/%d/translations/exports', $projectId);
         return $this->_post($path, DownloadFile::class, $params);
+    }
+
+    /**
+     * Translation Alignment
+     * @link https://developer.crowdin.com/api/v2/#operation/api.projects.translations.alignment.post API Documentation
+     * @link https://developer.crowdin.com/enterprise/api/v2/#operation/api.projects.translations.alignment.post API Documentation Enterprise
+     *
+     * @param int   $projectId
+     * @param array $params
+     * string $params[sourceLanguageId] required<br>
+     * string $params[targetLanguageId] required<br>
+     * string $params[text] required
+     *
+     * @return TranslationAlignment|null
+     */
+    public function alignment(int $projectId, array $params): ?TranslationAlignment
+    {
+        $path = sprintf('projects/%d/translations/alignment', $projectId);
+        return $this->_post($path, TranslationAlignment::class, $params);
     }
 }

--- a/src/CrowdinApiClient/Api/TranslationMemoryApi.php
+++ b/src/CrowdinApiClient/Api/TranslationMemoryApi.php
@@ -2,8 +2,10 @@
 
 namespace CrowdinApiClient\Api;
 
+use CrowdinApiClient\Http\ResponseDecorator\ResponseModelListDecorator;
 use CrowdinApiClient\Model\DownloadFile;
 use CrowdinApiClient\Model\TranslationMemory;
+use CrowdinApiClient\Model\TranslationMemoryConcordance;
 use CrowdinApiClient\Model\TranslationMemoryExport;
 use CrowdinApiClient\Model\TranslationMemoryImport;
 use CrowdinApiClient\ModelCollection;
@@ -164,5 +166,33 @@ class TranslationMemoryApi extends AbstractApi
     {
         $path = sprintf('tms/%d/imports/%s', $translationMemoryId, $importId);
         return $this->_get($path, TranslationMemoryImport::class);
+    }
+
+    /**
+     * Concordance search in TMs
+     * @link https://developer.crowdin.com/api/v2/#operation/api.projects.tms.concordance.post API Documentation
+     * @link https://developer.crowdin.com/enterprise/api/v2/#operation/api.projects.tms.concordance.post API Documentation Enterprise
+     *
+     * @param int $projectId
+     * @param array $params
+     * string $params[sourceLanguageId] required<br>
+     * string $params[targetLanguageId] required<br>
+     * bool $params[autoSubstitution] required Improves TM suggestions<br>
+     * int $params[minRelevant] required Show TM suggestions with specified minimum match (1-100)<br>
+     * string[] $params[expressions] required Note: Can't be used with expression in same request<br>
+     * string $params[expression] Deprecated Note: Can't be used with expressions in same request
+     * @return ModelCollection|null
+     */
+    public function concordance(int $projectId, array $params): ?ModelCollection
+    {
+        return $this->client->apiRequest(
+            'post',
+            sprintf('projects/%d/tms/concordance', $projectId),
+            new ResponseModelListDecorator(TranslationMemoryConcordance::class),
+            [
+                'body' => json_encode($params),
+                'headers' => $this->getHeaders(),
+            ]
+        );
     }
 }

--- a/src/CrowdinApiClient/Model/Alignment.php
+++ b/src/CrowdinApiClient/Model/Alignment.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CrowdinApiClient\Model;
+
+/**
+ * @package Crowdin\Model
+ */
+class Alignment extends BaseModel
+{
+    /**
+     * @var string
+     */
+    protected $sourceWord;
+
+    /**
+     * @var string
+     */
+    protected $sourceLemma;
+
+    /**
+     * @var string
+     */
+    protected $targetWord;
+
+    /**
+     * @var string
+     */
+    protected $targetLemma;
+
+    /**
+     * @var int
+     */
+    protected $match;
+
+    /**
+     * @var float
+     */
+    protected $probability;
+
+    public function __construct(array $data = [])
+    {
+        parent::__construct($data);
+
+        $this->sourceWord = (string)$this->getDataProperty('sourceWord');
+        $this->sourceLemma = (string)$this->getDataProperty('sourceLemma');
+        $this->targetWord = (string)$this->getDataProperty('targetWord');
+        $this->targetLemma = (string)$this->getDataProperty('targetLemma');
+        $this->match = (int)$this->getDataProperty('match');
+        $this->probability = (float)$this->getDataProperty('probability');
+    }
+
+    /**
+     * @return string
+     */
+    public function getSourceWord(): string
+    {
+        return $this->sourceWord;
+    }
+
+    /**
+     * @return string
+     */
+    public function getSourceLemma(): string
+    {
+        return $this->sourceLemma;
+    }
+
+    /**
+     * @return string
+     */
+    public function getTargetWord(): string
+    {
+        return $this->targetWord;
+    }
+
+    /**
+     * @return string
+     */
+    public function getTargetLemma(): string
+    {
+        return $this->targetLemma;
+    }
+
+    /**
+     * @return int
+     */
+    public function getMatch(): int
+    {
+        return $this->match;
+    }
+
+    /**
+     * @return float
+     */
+    public function getProbability(): float
+    {
+        return $this->probability;
+    }
+}

--- a/src/CrowdinApiClient/Model/TranslationAlignment.php
+++ b/src/CrowdinApiClient/Model/TranslationAlignment.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CrowdinApiClient\Model;
+
+/**
+ * @package Crowdin\Model
+ */
+class TranslationAlignment extends BaseModel
+{
+    /**
+     * @var WordAlignment[]
+     */
+    protected $words;
+
+    public function __construct(array $data = [])
+    {
+        parent::__construct($data);
+
+        $this->words = array_map(
+            static function (array $word): WordAlignment {
+                return new WordAlignment($word);
+            },
+            (array)$this->getDataProperty('words')
+        );
+    }
+
+    /**
+     * @return WordAlignment[]
+     */
+    public function getWords(): array
+    {
+        return $this->words;
+    }
+}

--- a/src/CrowdinApiClient/Model/TranslationMemoryConcordance.php
+++ b/src/CrowdinApiClient/Model/TranslationMemoryConcordance.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CrowdinApiClient\Model;
+
+/**
+ * @package Crowdin\Model
+ */
+class TranslationMemoryConcordance extends BaseModel
+{
+    /**
+     * @var TranslationMemory
+     */
+    protected $tm;
+
+    /**
+     * @var int
+     */
+    protected $recordId;
+
+    /**
+     * @var string
+     */
+    protected $source;
+
+    /**
+     * @var string
+     */
+    protected $target;
+
+    /**
+     * @var int
+     */
+    protected $relevant;
+
+    /**
+     * @var string|null
+     */
+    protected $substituted;
+
+    /**
+     * @var string|null
+     */
+    protected $updatedAt;
+
+    public function __construct(array $data)
+    {
+        parent::__construct($data);
+
+        $this->tm = new TranslationMemory($this->getDataProperty('tm'));
+        $this->recordId = (int)$this->getDataProperty('recordId');
+        $this->source = (string)$this->getDataProperty('source');
+        $this->target = (string)$this->getDataProperty('target');
+        $this->relevant = (int)$this->getDataProperty('relevant');
+        $this->substituted = $this->getDataProperty('substituted');
+        $this->updatedAt = $this->getDataProperty('updatedAt');
+    }
+
+    public function getTm(): TranslationMemory
+    {
+        return $this->tm;
+    }
+
+    public function getRecordId(): int
+    {
+        return $this->recordId;
+    }
+
+    public function getSource(): string
+    {
+        return $this->source;
+    }
+
+    public function getTarget(): string
+    {
+        return $this->target;
+    }
+
+    public function getRelevant(): int
+    {
+        return $this->relevant;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getSubstituted(): ?string
+    {
+        return $this->substituted;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getUpdatedAt(): ?string
+    {
+        return $this->updatedAt;
+    }
+}

--- a/src/CrowdinApiClient/Model/WordAlignment.php
+++ b/src/CrowdinApiClient/Model/WordAlignment.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CrowdinApiClient\Model;
+
+/**
+ * @package Crowdin\Model
+ */
+class WordAlignment extends BaseModel
+{
+    /**
+     * @var string
+     */
+    protected $text;
+
+    /**
+     * @var Alignment[]
+     */
+    protected $alignments;
+
+    public function __construct(array $data = [])
+    {
+        parent::__construct($data);
+
+        $this->text = (string)$this->getDataProperty('text');
+        $this->alignments = array_map(
+            static function (array $alignment): Alignment {
+                return new Alignment($alignment);
+            },
+            (array)$this->getDataProperty('alignments')
+        );
+    }
+
+    /**
+     * @return string
+     */
+    public function getText(): string
+    {
+        return $this->text;
+    }
+
+    /**
+     * @return Alignment[]
+     */
+    public function getAlignments(): array
+    {
+        return $this->alignments;
+    }
+}

--- a/tests/CrowdinApiClient/Model/AlignmentTest.php
+++ b/tests/CrowdinApiClient/Model/AlignmentTest.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CrowdinApiClient\Tests\Model;
+
+use CrowdinApiClient\Model\Alignment;
+use PHPUnit\Framework\TestCase;
+
+class AlignmentTest extends TestCase
+{
+    /**
+     * @var Alignment
+     */
+    public $alignment;
+
+    /**
+     * @var array
+     */
+    public $data = [
+        'sourceWord' => 'Password',
+        'sourceLemma' => 'password',
+        'targetWord' => 'Пароль',
+        'targetLemma' => 'пароль',
+        'match' => 2,
+        'probability' => 2.0,
+    ];
+
+    public function testLoadData(): void
+    {
+        $this->alignment = new Alignment($this->data);
+        $this->checkData();
+    }
+
+    public function checkData(): void
+    {
+        $this->assertEquals($this->data['sourceWord'], $this->alignment->getSourceWord());
+        $this->assertEquals($this->data['sourceLemma'], $this->alignment->getSourceLemma());
+        $this->assertEquals($this->data['targetWord'], $this->alignment->getTargetWord());
+        $this->assertEquals($this->data['targetLemma'], $this->alignment->getTargetLemma());
+        $this->assertEquals($this->data['match'], $this->alignment->getMatch());
+        $this->assertEquals($this->data['probability'], $this->alignment->getProbability());
+    }
+}

--- a/tests/CrowdinApiClient/Model/TranslationAlignmentTest.php
+++ b/tests/CrowdinApiClient/Model/TranslationAlignmentTest.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CrowdinApiClient\Tests\Model;
+
+use CrowdinApiClient\Model\TranslationAlignment;
+use CrowdinApiClient\Model\WordAlignment;
+use PHPUnit\Framework\TestCase;
+
+class TranslationAlignmentTest extends TestCase
+{
+    /**
+     * @var TranslationAlignment
+     */
+    public $translationAlignment;
+
+    /**
+     * @var array
+     */
+    public $data = [
+        'words' => [
+            [
+                'text' => 'password',
+                'alignments' => [
+                    [
+                        'sourceWord' => 'Password',
+                        'sourceLemma' => 'password',
+                        'targetWord' => 'Пароль',
+                        'targetLemma' => 'пароль',
+                        'match' => 2,
+                        'probability' => 2.0,
+                    ],
+                ],
+            ],
+        ],
+    ];
+
+    public function testLoadData(): void
+    {
+        $this->translationAlignment = new TranslationAlignment($this->data);
+        $this->checkData();
+    }
+
+    public function checkData(): void
+    {
+        $this->assertIsArray($this->translationAlignment->getWords());
+        $this->assertCount(count($this->data['words']), $this->translationAlignment->getWords());
+        $this->assertContainsOnlyInstancesOf(
+            WordAlignment::class,
+            $this->translationAlignment->getWords()
+        );
+    }
+}

--- a/tests/CrowdinApiClient/Model/TranslationMemoryConcordanceTest.php
+++ b/tests/CrowdinApiClient/Model/TranslationMemoryConcordanceTest.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CrowdinApiClient\Tests\Model;
+
+use CrowdinApiClient\Model\TranslationMemory;
+use CrowdinApiClient\Model\TranslationMemoryConcordance;
+use PHPUnit\Framework\TestCase;
+
+class TranslationMemoryConcordanceTest extends TestCase
+{
+    /**
+     * @var TranslationMemoryConcordance
+     */
+    public $translationMemoryConcordance;
+
+    /**
+     * @var array
+     */
+    public $data = [
+        'tm' => [
+            'id' => 4,
+            'name' => 'Knowledge Base TM',
+        ],
+        'recordId' => 34,
+        'source' => 'Welcome!',
+        'target' => 'Ласкаво просимо!',
+        'relevant' => 100,
+        'substituted' => '62→100',
+        'updatedAt' => '2022-09-28T12:29:34+00:00',
+    ];
+
+    public function testLoadData(): void
+    {
+        $this->translationMemoryConcordance = new TranslationMemoryConcordance($this->data);
+        $this->checkData();
+    }
+
+    public function checkData(): void
+    {
+        $this->assertInstanceOf(TranslationMemory::class, $this->translationMemoryConcordance->getTm());
+        $this->assertEquals($this->data['tm']['id'], $this->translationMemoryConcordance->getTm()->getId());
+        $this->assertEquals($this->data['tm']['name'], $this->translationMemoryConcordance->getTm()->getName());
+        $this->assertEquals($this->data['recordId'], $this->translationMemoryConcordance->getRecordId());
+        $this->assertEquals($this->data['source'], $this->translationMemoryConcordance->getSource());
+        $this->assertEquals($this->data['target'], $this->translationMemoryConcordance->getTarget());
+        $this->assertEquals($this->data['relevant'], $this->translationMemoryConcordance->getRelevant());
+        $this->assertEquals($this->data['substituted'], $this->translationMemoryConcordance->getSubstituted());
+        $this->assertEquals($this->data['updatedAt'], $this->translationMemoryConcordance->getUpdatedAt());
+    }
+}

--- a/tests/CrowdinApiClient/Model/WordAlignmentTest.php
+++ b/tests/CrowdinApiClient/Model/WordAlignmentTest.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CrowdinApiClient\Tests\Model;
+
+use CrowdinApiClient\Model\Alignment;
+use CrowdinApiClient\Model\WordAlignment;
+use PHPUnit\Framework\TestCase;
+
+class WordAlignmentTest extends TestCase
+{
+    /**
+     * @var WordAlignment
+     */
+    public $wordAlignment;
+
+    /**
+     * @var array
+     */
+    public $data = [
+        'text' => 'password',
+        'alignments' => [
+            [
+                'sourceWord' => 'Password',
+                'sourceLemma' => 'password',
+                'targetWord' => 'Пароль',
+                'targetLemma' => 'пароль',
+                'match' => 2,
+                'probability' => 2.0,
+            ],
+        ],
+    ];
+
+    public function testLoadData(): void
+    {
+        $this->wordAlignment = new WordAlignment($this->data);
+        $this->checkData();
+    }
+
+    public function checkData(): void
+    {
+        $this->assertEquals($this->data['text'], $this->wordAlignment->getText());
+        $this->assertIsArray($this->wordAlignment->getAlignments());
+        $this->assertCount(count($this->data['alignments']), $this->wordAlignment->getAlignments());
+        $this->assertContainsOnlyInstancesOf(
+            Alignment::class,
+            $this->wordAlignment->getAlignments()
+        );
+    }
+}


### PR DESCRIPTION
Adds support for the following APIs

- [api.projects.translations.alignment.post](https://developer.crowdin.com/api/v2/#operation/api.projects.translations.alignment.post)
- [api.projects.tms.concordance.post](https://developer.crowdin.com/api/v2/#operation/api.projects.tms.concordance.post)

One API from #122 had already been implemented

- [api.projects.glossaries.concordance.post](https://developer.crowdin.com/api/v2/#operation/api.projects.glossaries.concordance.post)

Closes #122