### PR TITLE
feat: Add support for new Task Comments API

### DIFF
--- a/src/CrowdinApiClient/Api/TaskCommentApi.php
+++ b/src/CrowdinApiClient/Api/TaskCommentApi.php
@@ -81,4 +81,20 @@ class TaskCommentApi extends AbstractApi
         $path = sprintf('projects/%d/tasks/%d/comments/%d', $projectId, $taskId, $taskComment->getId());
         return $this->_update($path, $taskComment);
     }
+
+    /**
+     * Delete Task Comment
+     * @link https://developer.crowdin.com/api/v2/#operation/api.projects.tasks.comments.delete API Documentation
+     * @link https://developer.crowdin.com/enterprise/api/v2/#operation/api.projects.tasks.comments.delete API Documentation Enterprise
+     *
+     * @param int $projectId
+     * @param int $taskId
+     * @param int $commentId
+     * @return mixed
+     */
+    public function delete(int $projectId, int $taskId, int $commentId)
+    {
+        $path = sprintf('projects/%d/tasks/%d/comments/%d', $projectId, $taskId, $commentId);
+        return $this->_delete($path);
+    }
 }

--- a/src/CrowdinApiClient/Api/TaskCommentApi.php
+++ b/src/CrowdinApiClient/Api/TaskCommentApi.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace CrowdinApiClient\Api;
+
+use CrowdinApiClient\Model\TaskComment;
+use CrowdinApiClient\ModelCollection;
+
+/**
+ * Manage comments on tasks within projects
+ *
+ * @package Crowdin\Api
+ */
+class TaskCommentApi extends AbstractApi
+{
+    /**
+     * List Task Comments
+     * @link https://developer.crowdin.com/api/v2/#operation/api.projects.tasks.comments.getMany API Documentation
+     * @link https://developer.crowdin.com/enterprise/api/v2/#operation/api.projects.tasks.comments.getMany API Documentation Enterprise
+     *
+     * @param int $projectId
+     * @param int $taskId
+     * @param array $params
+     * integer $params[limit] Default: 25<br>
+     * integer $params[offset] Default: 0<br>
+     *
+     * @return ModelCollection
+     */
+    public function list(int $projectId, int $taskId, array $params = []): ModelCollection
+    {
+        $path = sprintf('projects/%d/tasks/%d/comments', $projectId, $taskId);
+        return $this->_list($path, TaskComment::class, $params);
+    }
+}

--- a/src/CrowdinApiClient/Api/TaskCommentApi.php
+++ b/src/CrowdinApiClient/Api/TaskCommentApi.php
@@ -46,4 +46,23 @@ class TaskCommentApi extends AbstractApi
         $path = sprintf('projects/%d/tasks/%d/comments/%d', $projectId, $taskId, $commentId);
         return $this->_get($path, TaskComment::class);
     }
+
+    /**
+     * Add Task Comment
+     * @link https://developer.crowdin.com/api/v2/#operation/api.projects.tasks.comments.post API Documentation
+     * @link https://developer.crowdin.com/enterprise/api/v2/#operation/api.projects.tasks.comments.post API Documentation Enterprise
+     *
+     * @param int $projectId
+     * @param int $taskId
+     * @param array $data
+     * string $data[text] Text comment<br>
+     * integer $data[timeSpent] Time spent on the task in seconds<br>
+     *
+     * @return TaskComment|null
+     */
+    public function create(int $projectId, int $taskId, array $data): ?TaskComment
+    {
+        $path = sprintf('projects/%d/tasks/%d/comments', $projectId, $taskId);
+        return $this->_create($path, TaskComment::class, $data);
+    }
 }

--- a/src/CrowdinApiClient/Api/TaskCommentApi.php
+++ b/src/CrowdinApiClient/Api/TaskCommentApi.php
@@ -65,4 +65,20 @@ class TaskCommentApi extends AbstractApi
         $path = sprintf('projects/%d/tasks/%d/comments', $projectId, $taskId);
         return $this->_create($path, TaskComment::class, $data);
     }
+
+    /**
+     * Edit Task Comment
+     * @link https://developer.crowdin.com/api/v2/#operation/api.projects.tasks.comments.patch API Documentation
+     * @link https://developer.crowdin.com/enterprise/api/v2/#operation/api.projects.tasks.comments.patch API Documentation Enterprise
+     *
+     * @param int $projectId
+     * @param int $taskId
+     * @param TaskComment $taskComment
+     * @return TaskComment|null
+     */
+    public function update(int $projectId, int $taskId, TaskComment $taskComment): ?TaskComment
+    {
+        $path = sprintf('projects/%d/tasks/%d/comments/%d', $projectId, $taskId, $taskComment->getId());
+        return $this->_update($path, $taskComment);
+    }
 }

--- a/src/CrowdinApiClient/Api/TaskCommentApi.php
+++ b/src/CrowdinApiClient/Api/TaskCommentApi.php
@@ -30,4 +30,20 @@ class TaskCommentApi extends AbstractApi
         $path = sprintf('projects/%d/tasks/%d/comments', $projectId, $taskId);
         return $this->_list($path, TaskComment::class, $params);
     }
+
+    /**
+     * Get Task Comment
+     * @link https://developer.crowdin.com/api/v2/#operation/api.projects.tasks.comments.get API Documentation
+     * @link https://developer.crowdin.com/enterprise/api/v2/#operation/api.projects.tasks.comments.get API Documentation Enterprise
+     *
+     * @param int $projectId
+     * @param int $taskId
+     * @param int $commentId
+     * @return TaskComment|null
+     */
+    public function get(int $projectId, int $taskId, int $commentId): ?TaskComment
+    {
+        $path = sprintf('projects/%d/tasks/%d/comments/%d', $projectId, $taskId, $commentId);
+        return $this->_get($path, TaskComment::class);
+    }
 }

--- a/src/CrowdinApiClient/Crowdin.php
+++ b/src/CrowdinApiClient/Crowdin.php
@@ -19,6 +19,7 @@ use UnexpectedValueException;
  * @property \CrowdinApiClient\Api\ProjectApi $project
  * @property \CrowdinApiClient\Api\BranchApi $branch
  * @property \CrowdinApiClient\Api\TaskApi $task
+ * @property \CrowdinApiClient\Api\TaskCommentApi $taskComment
  * @property \CrowdinApiClient\Api\IssueApi $issue
  * @property \CrowdinApiClient\Api\ScreenshotApi $screenshot
  * @property \CrowdinApiClient\Api\DirectoryApi $directory
@@ -92,6 +93,7 @@ class Crowdin
         'language',
         'project',
         'task',
+        'taskComment',
         'issue',
         'branch',
         'glossary',
@@ -124,6 +126,7 @@ class Crowdin
         'group',
         'project',
         'task',
+        'taskComment',
         'issue',
         'branch',
         'glossary',

--- a/src/CrowdinApiClient/Model/TaskComment.php
+++ b/src/CrowdinApiClient/Model/TaskComment.php
@@ -1,0 +1,129 @@
+<?php
+
+namespace CrowdinApiClient\Model;
+
+/**
+ * @package Crowdin\Model
+ */
+class TaskComment extends BaseModel
+{
+    /**
+     * @var integer
+     */
+    protected $id;
+
+    /**
+     * @var integer
+     */
+    protected $userId;
+
+    /**
+     * @var integer
+     */
+    protected $taskId;
+
+    /**
+     * @var string
+     */
+    protected $text;
+
+    /**
+     * @var integer|null
+     */
+    protected $timeSpent;
+
+    /**
+     * @var string
+     */
+    protected $createdAt;
+
+    /**
+     * @var string
+     */
+    protected $updatedAt;
+
+    public function __construct(array $data = [])
+    {
+        parent::__construct($data);
+
+        $this->id = (integer)$this->getDataProperty('id');
+        $this->userId = (integer)$this->getDataProperty('userId');
+        $this->taskId = (integer)$this->getDataProperty('taskId');
+        $this->text = (string)$this->getDataProperty('text');
+        $this->timeSpent = $this->getDataProperty('timeSpent') ? (integer)$this->getDataProperty('timeSpent') : null;
+        $this->createdAt = (string)$this->getDataProperty('createdAt');
+        $this->updatedAt = (string)$this->getDataProperty('updatedAt');
+    }
+
+    /**
+     * @return int
+     */
+    public function getId(): int
+    {
+        return $this->id;
+    }
+
+    /**
+     * @return int
+     */
+    public function getUserId(): int
+    {
+        return $this->userId;
+    }
+
+    /**
+     * @return int
+     */
+    public function getTaskId(): int
+    {
+        return $this->taskId;
+    }
+
+    /**
+     * @return string
+     */
+    public function getText(): string
+    {
+        return $this->text;
+    }
+
+    /**
+     * @param string $text
+     */
+    public function setText(string $text): void
+    {
+        $this->text = $text;
+    }
+
+    /**
+     * @return int|null
+     */
+    public function getTimeSpent(): ?int
+    {
+        return $this->timeSpent;
+    }
+
+    /**
+     * @param int|null $timeSpent
+     */
+    public function setTimeSpent(?int $timeSpent): void
+    {
+        $this->timeSpent = $timeSpent;
+    }
+
+    /**
+     * @return string
+     */
+    public function getCreatedAt(): string
+    {
+        return $this->createdAt;
+    }
+
+    /**
+     * @return string
+     */
+    public function getUpdatedAt(): string
+    {
+        return $this->updatedAt;
+    }
+}

--- a/tests/CrowdinApiClient/Api/TaskCommentApiTest.php
+++ b/tests/CrowdinApiClient/Api/TaskCommentApiTest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace CrowdinApiClient\Tests\Api;
+
+use CrowdinApiClient\Model\TaskComment;
+use CrowdinApiClient\ModelCollection;
+
+class TaskCommentApiTest extends AbstractTestApi
+{
+    public function testList()
+    {
+        $this->mockRequest([
+            'path' => '/projects/2/tasks/203/comments',
+            'method' => 'get',
+            'response' => '{
+                  "data": [
+                    {
+                      "data": {
+                        "id": 1233,
+                        "userId": 5,
+                        "taskId": 203,
+                        "text": "translate task",
+                        "timeSpent": 3600,
+                        "createdAt": "2019-09-23T09:04:29+00:00",
+                        "updatedAt": "2019-09-23T09:04:29+00:00"
+                      }
+                    }
+                  ],
+                  "pagination": [
+                    {
+                      "offset": 0,
+                      "limit": 0
+                    }
+                  ]
+                }'
+        ]);
+
+        $taskComments = $this->crowdin->taskComment->list(2, 203);
+        $this->assertInstanceOf(ModelCollection::class, $taskComments);
+        $this->assertCount(1, $taskComments);
+        $this->assertInstanceOf(TaskComment::class, $taskComments[0]);
+        $this->assertEquals(1233, $taskComments[0]->getId());
+    }
+}

--- a/tests/CrowdinApiClient/Api/TaskCommentApiTest.php
+++ b/tests/CrowdinApiClient/Api/TaskCommentApiTest.php
@@ -64,4 +64,33 @@ class TaskCommentApiTest extends AbstractTestApi
         $this->assertInstanceOf(TaskComment::class, $taskComment);
         $this->assertEquals(1233, $taskComment->getId());
     }
+
+    public function testCreate()
+    {
+        $params = [
+            'text' => 'Work in task',
+            'timeSpent' => 3600,
+        ];
+
+        $this->mockRequest([
+            'path' => '/projects/2/tasks/203/comments',
+            'method' => 'post',
+            'body' => json_encode($params),
+            'response' => '{
+                  "data": {
+                    "id": 1233,
+                    "userId": 5,
+                    "taskId": 203,
+                    "text": "Work in task",
+                    "timeSpent": 3600,
+                    "createdAt": "2019-09-23T09:04:29+00:00",
+                    "updatedAt": "2019-09-23T09:04:29+00:00"
+                  }
+                }'
+        ]);
+
+        $taskComment = $this->crowdin->taskComment->create(2, 203, $params);
+        $this->assertInstanceOf(TaskComment::class, $taskComment);
+        $this->assertEquals(1233, $taskComment->getId());
+    }
 }

--- a/tests/CrowdinApiClient/Api/TaskCommentApiTest.php
+++ b/tests/CrowdinApiClient/Api/TaskCommentApiTest.php
@@ -41,4 +41,27 @@ class TaskCommentApiTest extends AbstractTestApi
         $this->assertInstanceOf(TaskComment::class, $taskComments[0]);
         $this->assertEquals(1233, $taskComments[0]->getId());
     }
+
+    public function testGet()
+    {
+        $this->mockRequest([
+            'path' => '/projects/2/tasks/203/comments/1233',
+            'method' => 'get',
+            'response' => '{
+                  "data": {
+                    "id": 1233,
+                    "userId": 5,
+                    "taskId": 203,
+                    "text": "translate task",
+                    "timeSpent": 3600,
+                    "createdAt": "2019-09-23T09:04:29+00:00",
+                    "updatedAt": "2019-09-23T09:04:29+00:00"
+                  }
+                }'
+        ]);
+
+        $taskComment = $this->crowdin->taskComment->get(2, 203, 1233);
+        $this->assertInstanceOf(TaskComment::class, $taskComment);
+        $this->assertEquals(1233, $taskComment->getId());
+    }
 }

--- a/tests/CrowdinApiClient/Api/TaskCommentApiTest.php
+++ b/tests/CrowdinApiClient/Api/TaskCommentApiTest.php
@@ -93,4 +93,46 @@ class TaskCommentApiTest extends AbstractTestApi
         $this->assertInstanceOf(TaskComment::class, $taskComment);
         $this->assertEquals(1233, $taskComment->getId());
     }
+
+    public function testUpdate()
+    {
+        $this->mockRequest([
+            'path' => '/projects/2/tasks/203/comments/1233',
+            'method' => 'get',
+            'response' => '{
+                  "data": {
+                    "id": 1233,
+                    "userId": 5,
+                    "taskId": 203,
+                    "text": "translate task",
+                    "timeSpent": 3600,
+                    "createdAt": "2019-09-23T09:04:29+00:00",
+                    "updatedAt": "2019-09-23T09:04:29+00:00"
+                  }
+                }'
+        ]);
+
+        $taskComment = $this->crowdin->taskComment->get(2, 203, 1233);
+        $this->assertInstanceOf(TaskComment::class, $taskComment);
+        $this->assertEquals(1233, $taskComment->getId());
+        $this->assertEquals('translate task', $taskComment->getText());
+
+        $taskComment->setText('updated comment');
+
+        $this->mockRequestPatch('/projects/2/tasks/203/comments/1233', '{
+                  "data": {
+                    "id": 1233,
+                    "userId": 5,
+                    "taskId": 203,
+                    "text": "updated comment",
+                    "timeSpent": 3600,
+                    "createdAt": "2019-09-23T09:04:29+00:00",
+                    "updatedAt": "2019-09-23T09:04:29+00:00"
+                  }
+                }');
+
+        $taskComment = $this->crowdin->taskComment->update(2, 203, $taskComment);
+        $this->assertInstanceOf(TaskComment::class, $taskComment);
+        $this->assertEquals('updated comment', $taskComment->getText());
+    }
 }

--- a/tests/CrowdinApiClient/Api/TaskCommentApiTest.php
+++ b/tests/CrowdinApiClient/Api/TaskCommentApiTest.php
@@ -135,4 +135,10 @@ class TaskCommentApiTest extends AbstractTestApi
         $this->assertInstanceOf(TaskComment::class, $taskComment);
         $this->assertEquals('updated comment', $taskComment->getText());
     }
+
+    public function testDelete()
+    {
+        $this->mockRequestDelete('/projects/2/tasks/203/comments/1233');
+        $this->crowdin->taskComment->delete(2, 203, 1233);
+    }
 }

--- a/tests/CrowdinApiClient/Model/TaskCommentTest.php
+++ b/tests/CrowdinApiClient/Model/TaskCommentTest.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace CrowdinApiClient\Tests\Model;
+
+use CrowdinApiClient\Model\TaskComment;
+use PHPUnit\Framework\TestCase;
+
+class TaskCommentTest extends TestCase
+{
+    /**
+     * @var TaskComment
+     */
+    public $taskComment;
+
+    public $data = [
+        'id' => 1233,
+        'userId' => 5,
+        'taskId' => 203,
+        'text' => 'translate task',
+        'timeSpent' => 3600,
+        'createdAt' => '2019-09-23T09:04:29+00:00',
+        'updatedAt' => '2019-09-23T09:04:29+00:00',
+    ];
+
+    public function testLoadData()
+    {
+        $this->taskComment = new TaskComment($this->data);
+        $this->checkData();
+    }
+
+    public function testSetData()
+    {
+        $this->taskComment = new TaskComment();
+        $this->taskComment->setText($this->data['text']);
+        $this->taskComment->setTimeSpent($this->data['timeSpent']);
+
+        $this->assertEquals($this->data['text'], $this->taskComment->getText());
+        $this->assertEquals($this->data['timeSpent'], $this->taskComment->getTimeSpent());
+    }
+
+    public function checkData()
+    {
+        $this->assertEquals($this->data['id'], $this->taskComment->getId());
+        $this->assertEquals($this->data['userId'], $this->taskComment->getUserId());
+        $this->assertEquals($this->data['taskId'], $this->taskComment->getTaskId());
+        $this->assertEquals($this->data['text'], $this->taskComment->getText());
+        $this->assertEquals($this->data['timeSpent'], $this->taskComment->getTimeSpent());
+        $this->assertEquals($this->data['createdAt'], $this->taskComment->getCreatedAt());
+        $this->assertEquals($this->data['updatedAt'], $this->taskComment->getUpdatedAt());
+    }
+}


### PR DESCRIPTION
Adds support for the following Task Comments API endpoints

- [List Task Comments](https://support.crowdin.com/developer/api/v2/#tag/Tasks/operation/api.projects.tasks.comments.getMany)
- [Get Task Comment](https://support.crowdin.com/developer/api/v2/#tag/Tasks/operation/api.projects.tasks.comments.get)
- [Add Task Comment](https://support.crowdin.com/developer/api/v2/#tag/Tasks/operation/api.projects.tasks.comments.post)
- [Delete Task Comment](https://support.crowdin.com/developer/api/v2/#tag/Tasks/operation/api.projects.tasks.comments.delete)
- [Edit Task Comment](https://support.crowdin.com/developer/api/v2/#tag/Tasks/operation/api.projects.tasks.comments.patch)

Closes #231