### PR TITLE
feat: Add the Translation Memory Segments API support

### DIFF
--- a/src/CrowdinApiClient/Api/TranslationMemoryApi.php
+++ b/src/CrowdinApiClient/Api/TranslationMemoryApi.php
@@ -150,6 +150,21 @@ class TranslationMemoryApi extends AbstractApi
     }
 
     /**
+     * Delete TM Segment
+     * @link https://developer.crowdin.com/api/v2/#operation/api.tms.segments.delete API Documentation
+     * @link https://developer.crowdin.com/enterprise/api/v2/#operation/api.tms.segments.delete API Documentation Enterprise
+     *
+     * @param int $tmId
+     * @param int $segmentId
+     * @return null
+     */
+    public function deleteSegment(int $tmId, int $segmentId)
+    {
+        $path = sprintf('tms/%d/segments/%d', $tmId, $segmentId);
+        return $this->_delete($path);
+    }
+
+    /**
      * Export TM
      * @link https://developer.crowdin.com/api/v2/#operation/api.tms.exports.post API Documentation
      * @link https://developer.crowdin.com/enterprise/api/v2/#operation/api.tms.exports.post API Documentation Enterprise

--- a/src/CrowdinApiClient/Api/TranslationMemoryApi.php
+++ b/src/CrowdinApiClient/Api/TranslationMemoryApi.php
@@ -117,6 +117,21 @@ class TranslationMemoryApi extends AbstractApi
     }
 
     /**
+     * Get TM Segment
+     * @link https://developer.crowdin.com/api/v2/#operation/api.tms.segments.get API Documentation
+     * @link https://developer.crowdin.com/enterprise/api/v2/#operation/api.tms.segments.get API Documentation Enterprise
+     *
+     * @param int $tmId
+     * @param int $segmentId
+     * @return TranslationMemorySegment|null
+     */
+    public function getSegment(int $tmId, int $segmentId): ?TranslationMemorySegment
+    {
+        $path = sprintf('tms/%d/segments/%d', $tmId, $segmentId);
+        return $this->_get($path, TranslationMemorySegment::class);
+    }
+
+    /**
      * Export TM
      * @link https://developer.crowdin.com/api/v2/#operation/api.tms.exports.post API Documentation
      * @link https://developer.crowdin.com/enterprise/api/v2/#operation/api.tms.exports.post API Documentation Enterprise

--- a/src/CrowdinApiClient/Api/TranslationMemoryApi.php
+++ b/src/CrowdinApiClient/Api/TranslationMemoryApi.php
@@ -132,6 +132,24 @@ class TranslationMemoryApi extends AbstractApi
     }
 
     /**
+     * Create TM Segment
+     * @link https://developer.crowdin.com/api/v2/#operation/api.tms.segments.post API Documentation
+     * @link https://developer.crowdin.com/enterprise/api/v2/#operation/api.tms.segments.post API Documentation Enterprise
+     *
+     * @param int $tmId
+     * @param array $data
+     * array $data[records]<br>
+     * string $data[records][][languageId]<br>
+     * string $data[records][][text]
+     * @return TranslationMemorySegment|null
+     */
+    public function createSegment(int $tmId, array $data): ?TranslationMemorySegment
+    {
+        $path = sprintf('tms/%d/segments', $tmId);
+        return $this->_create($path, TranslationMemorySegment::class, $data);
+    }
+
+    /**
      * Export TM
      * @link https://developer.crowdin.com/api/v2/#operation/api.tms.exports.post API Documentation
      * @link https://developer.crowdin.com/enterprise/api/v2/#operation/api.tms.exports.post API Documentation Enterprise

--- a/src/CrowdinApiClient/Api/TranslationMemoryApi.php
+++ b/src/CrowdinApiClient/Api/TranslationMemoryApi.php
@@ -8,6 +8,7 @@ use CrowdinApiClient\Model\TranslationMemory;
 use CrowdinApiClient\Model\TranslationMemoryConcordance;
 use CrowdinApiClient\Model\TranslationMemoryExport;
 use CrowdinApiClient\Model\TranslationMemoryImport;
+use CrowdinApiClient\Model\TranslationMemorySegment;
 use CrowdinApiClient\ModelCollection;
 
 /**
@@ -94,6 +95,25 @@ class TranslationMemoryApi extends AbstractApi
     {
         $path = sprintf('tms/%d/segments', $translationMemoryId);
         return $this->_delete($path);
+    }
+
+    /**
+     * List TM Segments
+     * @link https://developer.crowdin.com/api/v2/#operation/api.tms.segments.getMany API Documentation
+     * @link https://developer.crowdin.com/enterprise/api/v2/#operation/api.tms.segments.getMany API Documentation Enterprise
+     *
+     * @param int $tmId
+     * @param array $params
+     * string $params[orderBy]<br>
+     * string $params[croql]<br>
+     * integer $params[limit]<br>
+     * integer $params[offset]
+     * @return ModelCollection
+     */
+    public function listSegments(int $tmId, array $params = []): ModelCollection
+    {
+        $path = sprintf('tms/%d/segments', $tmId);
+        return $this->_list($path, TranslationMemorySegment::class, $params);
     }
 
     /**

--- a/src/CrowdinApiClient/Model/TranslationMemorySegment.php
+++ b/src/CrowdinApiClient/Model/TranslationMemorySegment.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace CrowdinApiClient\Model;
+
+/**
+ * @package Crowdin\Model
+ */
+class TranslationMemorySegment extends BaseModel
+{
+    /**
+     * @var integer
+     */
+    protected $id;
+
+    /**
+     * @var TranslationMemorySegmentRecord[]
+     */
+    protected $records;
+
+    public function __construct(array $data = [])
+    {
+        parent::__construct($data);
+
+        $this->id = (integer)$this->getDataProperty('id');
+        $this->records = array_map(static function (array $record): TranslationMemorySegmentRecord {
+            return new TranslationMemorySegmentRecord($record);
+        }, (array)$this->getDataProperty('records'));
+    }
+
+    /**
+     * @return int
+     */
+    public function getId(): int
+    {
+        return $this->id;
+    }
+
+    /**
+     * @param int $id
+     */
+    public function setId(int $id): void
+    {
+        $this->id = $id;
+    }
+
+    /**
+     * @return TranslationMemorySegmentRecord[]
+     */
+    public function getRecords(): array
+    {
+        return $this->records;
+    }
+
+    /**
+     * @param TranslationMemorySegmentRecord[] $records
+     */
+    public function setRecords(array $records): void
+    {
+        $this->records = $records;
+    }
+}

--- a/src/CrowdinApiClient/Model/TranslationMemorySegmentRecord.php
+++ b/src/CrowdinApiClient/Model/TranslationMemorySegmentRecord.php
@@ -1,0 +1,190 @@
+<?php
+
+namespace CrowdinApiClient\Model;
+
+/**
+ * @package Crowdin\Model
+ */
+class TranslationMemorySegmentRecord extends BaseModel
+{
+    /**
+     * @var integer
+     */
+    protected $id;
+
+    /**
+     * @var string
+     */
+    protected $languageId;
+
+    /**
+     * @var string
+     */
+    protected $text;
+
+    /**
+     * @var integer
+     */
+    protected $usageCount;
+
+    /**
+     * @var integer
+     */
+    protected $createdBy;
+
+    /**
+     * @var integer
+     */
+    protected $updatedBy;
+
+    /**
+     * @var ?string
+     */
+    protected $createdAt;
+
+    /**
+     * @var ?string
+     */
+    protected $updatedAt;
+
+    public function __construct(array $data = [])
+    {
+        parent::__construct($data);
+        $this->id = (integer)$this->getDataProperty('id');
+        $this->languageId = (string)$this->getDataProperty('languageId');
+        $this->text = (string)$this->getDataProperty('text');
+        $this->usageCount = (integer)$this->getDataProperty('usageCount');
+        $this->createdBy = (integer)$this->getDataProperty('createdBy');
+        $this->updatedBy = (integer)$this->getDataProperty('updatedBy');
+        $this->createdAt = (string)$this->getDataProperty('createdAt');
+        $this->updatedAt = (string)$this->getDataProperty('updatedAt');
+    }
+
+    /**
+     * @return int
+     */
+    public function getId(): int
+    {
+        return $this->id;
+    }
+
+    /**
+     * @param int $id
+     */
+    public function setId(int $id): void
+    {
+        $this->id = $id;
+    }
+
+    /**
+     * @return string
+     */
+    public function getLanguageId(): string
+    {
+        return $this->languageId;
+    }
+
+    /**
+     * @param string $languageId
+     */
+    public function setLanguageId(string $languageId): void
+    {
+        $this->languageId = $languageId;
+    }
+
+    /**
+     * @return string
+     */
+    public function getText(): string
+    {
+        return $this->text;
+    }
+
+    /**
+     * @param string $text
+     */
+    public function setText(string $text): void
+    {
+        $this->text = $text;
+    }
+
+    /**
+     * @return int
+     */
+    public function getUsageCount(): int
+    {
+        return $this->usageCount;
+    }
+
+    /**
+     * @param int $usageCount
+     */
+    public function setUsageCount(int $usageCount): void
+    {
+        $this->usageCount = $usageCount;
+    }
+
+    /**
+     * @return int
+     */
+    public function getCreatedBy(): int
+    {
+        return $this->createdBy;
+    }
+
+    /**
+     * @param int $createdBy
+     */
+    public function setCreatedBy(int $createdBy): void
+    {
+        $this->createdBy = $createdBy;
+    }
+
+    /**
+     * @return int
+     */
+    public function getUpdatedBy(): int
+    {
+        return $this->updatedBy;
+    }
+
+    /**
+     * @param int $updatedBy
+     */
+    public function setUpdatedBy(int $updatedBy): void
+    {
+        $this->updatedBy = $updatedBy;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getCreatedAt(): ?string
+    {
+        return $this->createdAt;
+    }
+
+    /**
+     * @param string|null $createdAt
+     */
+    public function setCreatedAt(?string $createdAt): void
+    {
+        $this->createdAt = $createdAt;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getUpdatedAt(): ?string
+    {
+        return $this->updatedAt;
+    }
+
+    /**
+     * @param string|null $updatedAt
+     */
+    public function setUpdatedAt(?string $updatedAt): void
+    {
+        $this->updatedAt = $updatedAt;
+    }
+}

--- a/tests/CrowdinApiClient/Api/TranslationMemoryApiTest.php
+++ b/tests/CrowdinApiClient/Api/TranslationMemoryApiTest.php
@@ -417,4 +417,43 @@ class TranslationMemoryApiTest extends AbstractTestApi
         $this->assertInstanceOf(TranslationMemorySegment::class, $segment);
         $this->assertEquals(4, $segment->getId());
     }
+
+    public function testCreateSegment()
+    {
+        $params = [
+            'records' => [
+                [
+                    'languageId' => 'uk',
+                    'text' => 'Перекладений текст',
+                ],
+            ],
+        ];
+
+        $this->mockRequest([
+            'path' => '/tms/4/segments',
+            'method' => 'post',
+            'body' => json_encode($params),
+            'response' => '{
+              "data": {
+                "id": 4,
+                "records": [
+                  {
+                    "id": 1,
+                    "languageId": "uk",
+                    "text": "Перекладений текст",
+                    "usageCount": 13,
+                    "createdBy": 1,
+                    "updatedBy": 1,
+                    "createdAt": "2019-09-16T13:48:04+00:00",
+                    "updatedAt": "2019-09-16T13:48:04+00:00"
+                  }
+                ]
+              }
+            }'
+        ]);
+
+        $segment = $this->crowdin->translationMemory->createSegment(4, $params);
+        $this->assertInstanceOf(TranslationMemorySegment::class, $segment);
+        $this->assertEquals(4, $segment->getId());
+    }
 }

--- a/tests/CrowdinApiClient/Api/TranslationMemoryApiTest.php
+++ b/tests/CrowdinApiClient/Api/TranslationMemoryApiTest.php
@@ -392,4 +392,29 @@ class TranslationMemoryApiTest extends AbstractTestApi
         $this->assertInstanceOf(TranslationMemorySegment::class, $segments[0]);
         $this->assertEquals(4, $segments[0]->getId());
     }
+
+    public function testGetSegment()
+    {
+        $this->mockRequestGet('/tms/4/segments/1', '{
+          "data": {
+            "id": 4,
+            "records": [
+              {
+                "id": 1,
+                "languageId": "uk",
+                "text": "Перекладений текст",
+                "usageCount": 13,
+                "createdBy": 1,
+                "updatedBy": 1,
+                "createdAt": "2019-09-16T13:48:04+00:00",
+                "updatedAt": "2019-09-16T13:48:04+00:00"
+              }
+            ]
+          }
+        }');
+
+        $segment = $this->crowdin->translationMemory->getSegment(4, 1);
+        $this->assertInstanceOf(TranslationMemorySegment::class, $segment);
+        $this->assertEquals(4, $segment->getId());
+    }
 }

--- a/tests/CrowdinApiClient/Api/TranslationMemoryApiTest.php
+++ b/tests/CrowdinApiClient/Api/TranslationMemoryApiTest.php
@@ -456,4 +456,10 @@ class TranslationMemoryApiTest extends AbstractTestApi
         $this->assertInstanceOf(TranslationMemorySegment::class, $segment);
         $this->assertEquals(4, $segment->getId());
     }
+
+    public function testDeleteSegment()
+    {
+        $this->mockRequestDelete('/tms/4/segments/1');
+        $this->crowdin->translationMemory->deleteSegment(4, 1);
+    }
 }

--- a/tests/CrowdinApiClient/Api/TranslationMemoryApiTest.php
+++ b/tests/CrowdinApiClient/Api/TranslationMemoryApiTest.php
@@ -7,6 +7,7 @@ use CrowdinApiClient\Model\TranslationMemory;
 use CrowdinApiClient\Model\TranslationMemoryConcordance;
 use CrowdinApiClient\Model\TranslationMemoryExport;
 use CrowdinApiClient\Model\TranslationMemoryImport;
+use CrowdinApiClient\Model\TranslationMemorySegment;
 use CrowdinApiClient\ModelCollection;
 
 class TranslationMemoryApiTest extends AbstractTestApi
@@ -351,5 +352,44 @@ class TranslationMemoryApiTest extends AbstractTestApi
         $this->assertCount(1, $concordance);
         $this->assertInstanceOf(TranslationMemoryConcordance::class, $concordance[0]);
         $this->assertEquals(4, $concordance[0]->getTm()->getId());
+    }
+
+    public function testListSegments()
+    {
+        $this->mockRequest([
+            'path' => '/tms/4/segments',
+            'method' => 'get',
+            'response' => '{
+              "data": [
+                {
+                  "data": {
+                    "id": 4,
+                    "records": [
+                      {
+                        "id": 1,
+                        "languageId": "uk",
+                        "text": "Перекладений текст",
+                        "usageCount": 13,
+                        "createdBy": 1,
+                        "updatedBy": 1,
+                        "createdAt": "2019-09-16T13:48:04+00:00",
+                        "updatedAt": "2019-09-16T13:48:04+00:00"
+                      }
+                    ]
+                  }
+                }
+              ],
+              "pagination": {
+                "offset": 0,
+                "limit": 25
+              }
+            }'
+        ]);
+
+        $segments = $this->crowdin->translationMemory->listSegments(4);
+        $this->assertInstanceOf(ModelCollection::class, $segments);
+        $this->assertCount(1, $segments);
+        $this->assertInstanceOf(TranslationMemorySegment::class, $segments[0]);
+        $this->assertEquals(4, $segments[0]->getId());
     }
 }

--- a/tests/CrowdinApiClient/Model/TranslationMemorySegmentRecordTest.php
+++ b/tests/CrowdinApiClient/Model/TranslationMemorySegmentRecordTest.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace CrowdinApiClient\Test\Model;
+
+use CrowdinApiClient\Model\TranslationMemorySegmentRecord;
+use PHPUnit\Framework\TestCase;
+
+class TranslationMemorySegmentRecordTest extends TestCase
+{
+    /**
+     * @var TranslationMemorySegmentRecord
+     */
+    public $record;
+
+    /**
+     * @var array
+     */
+    public $data = [
+        'id' => 1,
+        'languageId' => 'uk',
+        'text' => 'Перекладений текст',
+        'usageCount' => 13,
+        'createdBy' => 1,
+        'updatedBy' => 1,
+        'createdAt' => '2019-09-16T13:48:04+00:00',
+        'updatedAt' => '2019-09-16T13:48:04+00:00',
+    ];
+
+    public function testLoadData()
+    {
+        $this->record = new TranslationMemorySegmentRecord($this->data);
+        $this->checkData();
+    }
+
+    public function testSetData()
+    {
+        $this->record = new TranslationMemorySegmentRecord();
+        $this->record->setId($this->data['id']);
+        $this->record->setLanguageId($this->data['languageId']);
+        $this->record->setText($this->data['text']);
+        $this->record->setUsageCount($this->data['usageCount']);
+        $this->record->setCreatedBy($this->data['createdBy']);
+        $this->record->setUpdatedBy($this->data['updatedBy']);
+        $this->record->setCreatedAt($this->data['createdAt']);
+        $this->record->setUpdatedAt($this->data['updatedAt']);
+
+        $this->assertEquals($this->data['id'], $this->record->getId());
+        $this->assertEquals($this->data['languageId'], $this->record->getLanguageId());
+        $this->assertEquals($this->data['text'], $this->record->getText());
+        $this->assertEquals($this->data['usageCount'], $this->record->getUsageCount());
+        $this->assertEquals($this->data['createdBy'], $this->record->getCreatedBy());
+        $this->assertEquals($this->data['updatedBy'], $this->record->getUpdatedBy());
+        $this->assertEquals($this->data['createdAt'], $this->record->getCreatedAt());
+        $this->assertEquals($this->data['updatedAt'], $this->record->getUpdatedAt());
+    }
+
+    public function checkData()
+    {
+        $this->assertEquals($this->data['id'], $this->record->getId());
+        $this->assertEquals($this->data['languageId'], $this->record->getLanguageId());
+        $this->assertEquals($this->data['text'], $this->record->getText());
+        $this->assertEquals($this->data['usageCount'], $this->record->getUsageCount());
+        $this->assertEquals($this->data['createdBy'], $this->record->getCreatedBy());
+        $this->assertEquals($this->data['updatedBy'], $this->record->getUpdatedBy());
+        $this->assertEquals($this->data['createdAt'], $this->record->getCreatedAt());
+        $this->assertEquals($this->data['updatedAt'], $this->record->getUpdatedAt());
+    }
+}

--- a/tests/CrowdinApiClient/Model/TranslationMemorySegmentTest.php
+++ b/tests/CrowdinApiClient/Model/TranslationMemorySegmentTest.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace CrowdinApiClient\Test\Model;
+
+use CrowdinApiClient\Model\TranslationMemorySegment;
+use CrowdinApiClient\Model\TranslationMemorySegmentRecord;
+use PHPUnit\Framework\TestCase;
+
+class TranslationMemorySegmentTest extends TestCase
+{
+    /**
+     * @var TranslationMemorySegment
+     */
+    public $segment;
+
+    /**
+     * @var array
+     */
+    public $data = [
+        'id' => 4,
+        'records' => [
+            [
+                'id' => 1,
+                'languageId' => 'uk',
+                'text' => 'Перекладений текст',
+                'usageCount' => 13,
+                'createdBy' => 1,
+                'updatedBy' => 1,
+                'createdAt' => '2019-09-16T13:48:04+00:00',
+                'updatedAt' => '2019-09-16T13:48:04+00:00',
+            ],
+        ],
+    ];
+
+    public function testLoadData()
+    {
+        $this->segment = new TranslationMemorySegment($this->data);
+        $this->checkData();
+    }
+
+    public function testSetData()
+    {
+        $this->segment = new TranslationMemorySegment();
+        $this->segment->setId($this->data['id']);
+
+        $record = new TranslationMemorySegmentRecord($this->data['records'][0]);
+        $this->segment->setRecords([$record]);
+
+        $this->assertEquals($this->data['id'], $this->segment->getId());
+        $this->assertIsArray($this->segment->getRecords());
+        $this->assertInstanceOf(TranslationMemorySegmentRecord::class, $this->segment->getRecords()[0]);
+        $this->assertEquals($this->data['records'][0]['id'], $this->segment->getRecords()[0]->getId());
+    }
+
+    public function checkData()
+    {
+        $this->assertEquals($this->data['id'], $this->segment->getId());
+        $this->assertIsArray($this->segment->getRecords());
+        $this->assertInstanceOf(TranslationMemorySegmentRecord::class, $this->segment->getRecords()[0]);
+        $this->assertEquals($this->data['records'][0]['id'], $this->segment->getRecords()[0]->getId());
+        $this->assertEquals($this->data['records'][0]['languageId'], $this->segment->getRecords()[0]->getLanguageId());
+        $this->assertEquals($this->data['records'][0]['text'], $this->segment->getRecords()[0]->getText());
+        $this->assertEquals($this->data['records'][0]['usageCount'], $this->segment->getRecords()[0]->getUsageCount());
+        $this->assertEquals($this->data['records'][0]['createdBy'], $this->segment->getRecords()[0]->getCreatedBy());
+        $this->assertEquals($this->data['records'][0]['updatedBy'], $this->segment->getRecords()[0]->getUpdatedBy());
+        $this->assertEquals($this->data['records'][0]['createdAt'], $this->segment->getRecords()[0]->getCreatedAt());
+        $this->assertEquals($this->data['records'][0]['updatedAt'], $this->segment->getRecords()[0]->getUpdatedAt());
+    }
+}


### PR DESCRIPTION
Adds support for the following Translation Memory Segments API endpoints

- [List TM Segments](https://developer.crowdin.com/api/v2/#operation/api.tms.segments.getMany)
- [Create TM Segment](https://developer.crowdin.com/api/v2/#operation/api.tms.segments.post)
- [Get TM Segment](https://developer.crowdin.com/api/v2/#operation/api.tms.segments.get)
- [Delete TM Segment](https://developer.crowdin.com/api/v2/#operation/api.tms.segments.delete)

Closes #128