### PR TITLE
feat: Add support for new String Corrections API

### DIFF
--- a/src/CrowdinApiClient/Api/Enterprise/StringCorrectionApi.php
+++ b/src/CrowdinApiClient/Api/Enterprise/StringCorrectionApi.php
@@ -95,4 +95,18 @@ class StringCorrectionApi extends AbstractApi
         $path = sprintf('projects/%d/corrections/%d', $projectId, $correctionId);
         return $this->_delete($path);
     }
+
+    /**
+     * Delete Corrections
+     * @link https://support.crowdin.com/developer/enterprise/api/v2/#tag/String-Corrections/operation/api.projects.corrections.deleteMany API Documentation
+     *
+     * @param int $projectId
+     * @param int $stringId
+     * @return mixed
+     */
+    public function deleteAll(int $projectId, int $stringId)
+    {
+        $path = sprintf('projects/%d/corrections', $projectId);
+        return $this->_delete($path, ['stringId' => $stringId]);
+    }
 }

--- a/src/CrowdinApiClient/Api/Enterprise/StringCorrectionApi.php
+++ b/src/CrowdinApiClient/Api/Enterprise/StringCorrectionApi.php
@@ -67,4 +67,18 @@ class StringCorrectionApi extends AbstractApi
         $path = sprintf('projects/%d/corrections', $projectId);
         return $this->_create($path, StringCorrection::class, $data);
     }
+
+    /**
+     * Restore Correction
+     * @link https://support.crowdin.com/developer/enterprise/api/v2/#tag/String-Corrections/operation/api.projects.corrections.put API Documentation
+     *
+     * @param int $projectId
+     * @param int $correctionId
+     * @return StringCorrection|null
+     */
+    public function restore(int $projectId, int $correctionId): ?StringCorrection
+    {
+        $path = sprintf('projects/%d/corrections/%d', $projectId, $correctionId);
+        return $this->_put($path, StringCorrection::class, []);
+    }
 }

--- a/src/CrowdinApiClient/Api/Enterprise/StringCorrectionApi.php
+++ b/src/CrowdinApiClient/Api/Enterprise/StringCorrectionApi.php
@@ -49,4 +49,22 @@ class StringCorrectionApi extends AbstractApi
         $path = sprintf('projects/%d/corrections/%d', $projectId, $correctionId);
         return $this->_get($path, StringCorrection::class, $params);
     }
+
+    /**
+     * Add Correction
+     * @link https://support.crowdin.com/developer/enterprise/api/v2/#tag/String-Corrections/operation/api.projects.corrections.post API Documentation
+     *
+     * @param int $projectId
+     * @param array $data
+     * integer $data[stringId] required<br>
+     * string $data[text] required<br>
+     * string $data[pluralCategoryName]
+     *
+     * @return StringCorrection|null
+     */
+    public function create(int $projectId, array $data): ?StringCorrection
+    {
+        $path = sprintf('projects/%d/corrections', $projectId);
+        return $this->_create($path, StringCorrection::class, $data);
+    }
 }

--- a/src/CrowdinApiClient/Api/Enterprise/StringCorrectionApi.php
+++ b/src/CrowdinApiClient/Api/Enterprise/StringCorrectionApi.php
@@ -81,4 +81,18 @@ class StringCorrectionApi extends AbstractApi
         $path = sprintf('projects/%d/corrections/%d', $projectId, $correctionId);
         return $this->_put($path, StringCorrection::class, []);
     }
+
+    /**
+     * Delete Correction
+     * @link https://support.crowdin.com/developer/enterprise/api/v2/#tag/String-Corrections/operation/api.projects.corrections.delete API Documentation
+     *
+     * @param int $projectId
+     * @param int $correctionId
+     * @return mixed
+     */
+    public function delete(int $projectId, int $correctionId)
+    {
+        $path = sprintf('projects/%d/corrections/%d', $projectId, $correctionId);
+        return $this->_delete($path);
+    }
 }

--- a/src/CrowdinApiClient/Api/Enterprise/StringCorrectionApi.php
+++ b/src/CrowdinApiClient/Api/Enterprise/StringCorrectionApi.php
@@ -32,4 +32,21 @@ class StringCorrectionApi extends AbstractApi
         $path = sprintf('projects/%d/corrections', $projectId);
         return $this->_list($path, StringCorrection::class, $params);
     }
+
+    /**
+     * Get Correction
+     * @link https://support.crowdin.com/developer/enterprise/api/v2/#tag/String-Corrections/operation/api.projects.corrections.get API Documentation
+     *
+     * @param int $projectId
+     * @param int $correctionId
+     * @param array $params
+     * integer $params[denormalizePlaceholders] default: 0
+     *
+     * @return StringCorrection|null
+     */
+    public function get(int $projectId, int $correctionId, array $params = []): ?StringCorrection
+    {
+        $path = sprintf('projects/%d/corrections/%d', $projectId, $correctionId);
+        return $this->_get($path, StringCorrection::class, $params);
+    }
 }

--- a/src/CrowdinApiClient/Api/Enterprise/StringCorrectionApi.php
+++ b/src/CrowdinApiClient/Api/Enterprise/StringCorrectionApi.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace CrowdinApiClient\Api\Enterprise;
+
+use CrowdinApiClient\Api\AbstractApi;
+use CrowdinApiClient\Model\StringCorrection;
+use CrowdinApiClient\ModelCollection;
+
+/**
+ * Use API to manage string corrections in Source Text Review workflow
+ *
+ * @package Crowdin\Api\Enterprise
+ */
+class StringCorrectionApi extends AbstractApi
+{
+    /**
+     * List Corrections
+     * @link https://support.crowdin.com/developer/enterprise/api/v2/#tag/String-Corrections/operation/api.projects.corrections.getMany API Documentation
+     *
+     * @param int $projectId
+     * @param array $params
+     * integer $params[stringId] required<br>
+     * integer $params[limit] default: 25<br>
+     * integer $params[offset] default: 0<br>
+     * string $params[orderBy]<br>
+     * integer $params[denormalizePlaceholders]
+     *
+     * @return ModelCollection
+     */
+    public function list(int $projectId, array $params = []): ModelCollection
+    {
+        $path = sprintf('projects/%d/corrections', $projectId);
+        return $this->_list($path, StringCorrection::class, $params);
+    }
+}

--- a/src/CrowdinApiClient/Crowdin.php
+++ b/src/CrowdinApiClient/Crowdin.php
@@ -48,6 +48,7 @@ use UnexpectedValueException;
  * @property \CrowdinApiClient\Api\ReportArchiveApi|\CrowdinApiClient\Api\Enterprise\ReportArchiveApi $reportArchive
  * @property \CrowdinApiClient\Api\GraphqlApi $graphql
  * @property \CrowdinApiClient\Api\SecurityLogApi|\CrowdinApiClient\Api\Enterprise\SecurityLogApi $securityLog
+ * @property \CrowdinApiClient\Api\Enterprise\StringCorrectionApi $stringCorrection
  */
 class Crowdin
 {
@@ -160,6 +161,7 @@ class Crowdin
         'reportArchive',
         'graphql',
         'securityLog',
+        'stringCorrection',
     ];
 
     public function __construct(array $config)

--- a/src/CrowdinApiClient/Model/StringCorrection.php
+++ b/src/CrowdinApiClient/Model/StringCorrection.php
@@ -1,0 +1,109 @@
+<?php
+
+namespace CrowdinApiClient\Model;
+
+/**
+ * @package Crowdin\Model
+ */
+class StringCorrection extends BaseModel
+{
+    /**
+     * @var integer
+     */
+    protected $id;
+
+    /**
+     * @var string
+     */
+    protected $text;
+
+    /**
+     * @var string
+     */
+    protected $pluralCategoryName;
+
+    /**
+     * @var array
+     */
+    protected $user;
+
+    /**
+     * @var string
+     */
+    protected $createdAt;
+
+    public function __construct(array $data = [])
+    {
+        parent::__construct($data);
+
+        $this->id = (integer)$this->getDataProperty('id');
+        $this->text = (string)$this->getDataProperty('text');
+        $this->pluralCategoryName = (string)$this->getDataProperty('pluralCategoryName');
+        $this->user = (array)$this->getDataProperty('user');
+        $this->createdAt = (string)$this->getDataProperty('createdAt');
+    }
+
+    /**
+     * @return int
+     */
+    public function getId(): int
+    {
+        return $this->id;
+    }
+
+    /**
+     * @return string
+     */
+    public function getText(): string
+    {
+        return $this->text;
+    }
+
+    /**
+     * @param string $text
+     */
+    public function setText(string $text): void
+    {
+        $this->text = $text;
+    }
+
+    /**
+     * @return string
+     */
+    public function getPluralCategoryName(): string
+    {
+        return $this->pluralCategoryName;
+    }
+
+    /**
+     * @param string $pluralCategoryName
+     */
+    public function setPluralCategoryName(string $pluralCategoryName): void
+    {
+        $this->pluralCategoryName = $pluralCategoryName;
+    }
+
+    /**
+     * @return array
+     */
+    public function getUser(): array
+    {
+        return $this->user;
+    }
+
+    /**
+     * @param array $user
+     */
+    public function setUser(array $user): void
+    {
+        $this->user = $user;
+    }
+
+    /**
+     * @return string
+     */
+    public function getCreatedAt(): string
+    {
+        return $this->createdAt;
+    }
+}

--- a/tests/CrowdinApiClient/Api/Enterprise/StringCorrectionApiTest.php
+++ b/tests/CrowdinApiClient/Api/Enterprise/StringCorrectionApiTest.php
@@ -132,4 +132,10 @@ class StringCorrectionApiTest extends AbstractTestApi
         $this->assertInstanceOf(StringCorrection::class, $correction);
         $this->assertEquals(190695, $correction->getId());
     }
+
+    public function testDelete(): void
+    {
+        $this->mockRequestDelete('/projects/2/corrections/190695');
+        $this->crowdin->stringCorrection->delete(2, 190695);
+    }
 }

--- a/tests/CrowdinApiClient/Api/Enterprise/StringCorrectionApiTest.php
+++ b/tests/CrowdinApiClient/Api/Enterprise/StringCorrectionApiTest.php
@@ -105,4 +105,31 @@ class StringCorrectionApiTest extends AbstractTestApi
         $this->assertEquals(190696, $correction->getId());
         $this->assertEquals('Corrected string text', $correction->getText());
     }
+
+    public function testRestore(): void
+    {
+        $this->mockRequest([
+            'path' => '/projects/2/corrections/190695',
+            'method' => 'put',
+            'response' => '{
+              "data": {
+                "id": 190695,
+                "text": "This string has been corrected",
+                "pluralCategoryName": "few",
+                "user": {
+                  "id": 19,
+                  "username": "john_doe",
+                  "fullName": "John Smith",
+                  "avatarUrl": ""
+                },
+                "createdAt": "2019-09-23T11:26:54+00:00"
+              }
+            }',
+        ]);
+
+        $correction = $this->crowdin->stringCorrection->restore(2, 190695);
+
+        $this->assertInstanceOf(StringCorrection::class, $correction);
+        $this->assertEquals(190695, $correction->getId());
+    }
 }

--- a/tests/CrowdinApiClient/Api/Enterprise/StringCorrectionApiTest.php
+++ b/tests/CrowdinApiClient/Api/Enterprise/StringCorrectionApiTest.php
@@ -43,4 +43,31 @@ class StringCorrectionApiTest extends AbstractTestApi
         $this->assertInstanceOf(StringCorrection::class, $corrections[0]);
         $this->assertEquals(190695, $corrections[0]->getId());
     }
+
+    public function testGet(): void
+    {
+        $this->mockRequestGet(
+            '/projects/2/corrections/190695',
+            '{
+              "data": {
+                "id": 190695,
+                "text": "This string has been corrected",
+                "pluralCategoryName": "few",
+                "user": {
+                  "id": 19,
+                  "username": "john_doe",
+                  "fullName": "John Smith",
+                  "avatarUrl": ""
+                },
+                "createdAt": "2019-09-23T11:26:54+00:00"
+              }
+            }'
+        );
+
+        $correction = $this->crowdin->stringCorrection->get(2, 190695);
+
+        $this->assertInstanceOf(StringCorrection::class, $correction);
+        $this->assertEquals(190695, $correction->getId());
+        $this->assertEquals('This string has been corrected', $correction->getText());
+    }
 }

--- a/tests/CrowdinApiClient/Api/Enterprise/StringCorrectionApiTest.php
+++ b/tests/CrowdinApiClient/Api/Enterprise/StringCorrectionApiTest.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace CrowdinApiClient\Tests\Api\Enterprise;
+
+use CrowdinApiClient\Model\StringCorrection;
+use CrowdinApiClient\ModelCollection;
+
+class StringCorrectionApiTest extends AbstractTestApi
+{
+    public function testList(): void
+    {
+        $this->mockRequest([
+            'path' => '/projects/2/corrections',
+            'method' => 'get',
+            'response' => '{
+              "data": [
+                {
+                  "data": {
+                    "id": 190695,
+                    "text": "This string has been corrected",
+                    "pluralCategoryName": "few",
+                    "user": {
+                      "id": 19,
+                      "username": "john_doe",
+                      "fullName": "John Smith",
+                      "avatarUrl": ""
+                    },
+                    "createdAt": "2019-09-23T11:26:54+00:00"
+                  }
+                }
+              ],
+              "pagination": {
+                "offset": 0,
+                "limit": 25
+              }
+            }',
+        ]);
+
+        $corrections = $this->crowdin->stringCorrection->list(2);
+
+        $this->assertInstanceOf(ModelCollection::class, $corrections);
+        $this->assertCount(1, $corrections);
+        $this->assertInstanceOf(StringCorrection::class, $corrections[0]);
+        $this->assertEquals(190695, $corrections[0]->getId());
+    }
+}

--- a/tests/CrowdinApiClient/Api/Enterprise/StringCorrectionApiTest.php
+++ b/tests/CrowdinApiClient/Api/Enterprise/StringCorrectionApiTest.php
@@ -70,4 +70,39 @@ class StringCorrectionApiTest extends AbstractTestApi
         $this->assertEquals(190695, $correction->getId());
         $this->assertEquals('This string has been corrected', $correction->getText());
     }
+
+    public function testCreate(): void
+    {
+        $params = [
+            'stringId' => 123,
+            'text' => 'Corrected string text',
+            'pluralCategoryName' => 'few',
+        ];
+
+        $this->mockRequest([
+            'path' => '/projects/2/corrections',
+            'method' => 'post',
+            'body' => json_encode($params),
+            'response' => '{
+              "data": {
+                "id": 190696,
+                "text": "Corrected string text",
+                "pluralCategoryName": "few",
+                "user": {
+                  "id": 19,
+                  "username": "john_doe",
+                  "fullName": "John Smith",
+                  "avatarUrl": ""
+                },
+                "createdAt": "2019-09-23T11:26:54+00:00"
+              }
+            }',
+        ]);
+
+        $correction = $this->crowdin->stringCorrection->create(2, $params);
+
+        $this->assertInstanceOf(StringCorrection::class, $correction);
+        $this->assertEquals(190696, $correction->getId());
+        $this->assertEquals('Corrected string text', $correction->getText());
+    }
 }

--- a/tests/CrowdinApiClient/Api/Enterprise/StringCorrectionApiTest.php
+++ b/tests/CrowdinApiClient/Api/Enterprise/StringCorrectionApiTest.php
@@ -138,4 +138,10 @@ class StringCorrectionApiTest extends AbstractTestApi
         $this->mockRequestDelete('/projects/2/corrections/190695');
         $this->crowdin->stringCorrection->delete(2, 190695);
     }
+
+    public function testDeleteAll(): void
+    {
+        $this->mockRequestDelete('/projects/2/corrections?stringId=123');
+        $this->crowdin->stringCorrection->deleteAll(2, 123);
+    }
 }

--- a/tests/CrowdinApiClient/Model/StringCorrectionTest.php
+++ b/tests/CrowdinApiClient/Model/StringCorrectionTest.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace CrowdinApiClient\Tests\Model;
+
+use CrowdinApiClient\Model\StringCorrection;
+use PHPUnit\Framework\TestCase;
+
+class StringCorrectionTest extends TestCase
+{
+    /**
+     * @var StringCorrection
+     */
+    public $stringCorrection;
+
+    public $data = [
+        'id' => 190695,
+        'text' => 'This string has been corrected',
+        'pluralCategoryName' => 'few',
+        'user' => [
+            'id' => 19,
+            'username' => 'john_doe',
+            'fullName' => 'John Smith',
+            'avatarUrl' => ''
+        ],
+        'createdAt' => '2019-09-23T11:26:54+00:00'
+    ];
+
+    public function testLoadData()
+    {
+        $this->stringCorrection = new StringCorrection($this->data);
+        $this->checkData();
+    }
+
+    public function testSetData()
+    {
+        $this->stringCorrection = new StringCorrection();
+        $this->stringCorrection->setText($this->data['text']);
+        $this->stringCorrection->setPluralCategoryName($this->data['pluralCategoryName']);
+        $this->stringCorrection->setUser($this->data['user']);
+
+        $this->assertEquals($this->data['text'], $this->stringCorrection->getText());
+        $this->assertEquals($this->data['pluralCategoryName'], $this->stringCorrection->getPluralCategoryName());
+        $this->assertEquals($this->data['user'], $this->stringCorrection->getUser());
+    }
+
+    public function checkData()
+    {
+        $this->assertEquals($this->data['id'], $this->stringCorrection->getId());
+        $this->assertEquals($this->data['text'], $this->stringCorrection->getText());
+        $this->assertEquals($this->data['pluralCategoryName'], $this->stringCorrection->getPluralCategoryName());
+        $this->assertEquals($this->data['createdAt'], $this->stringCorrection->getCreatedAt());
+
+        $this->assertEquals($this->data['user'], $this->stringCorrection->getUser());
+        $this->assertEquals($this->data['user']['id'], $this->stringCorrection->getUser()['id']);
+        $this->assertEquals($this->data['user']['username'], $this->stringCorrection->getUser()['username']);
+        $this->assertEquals($this->data['user']['fullName'], $this->stringCorrection->getUser()['fullName']);
+        $this->assertEquals($this->data['user']['avatarUrl'], $this->stringCorrection->getUser()['avatarUrl']);
+    }
+}


### PR DESCRIPTION
Adds support for the following String Corrections API endpoints

- [List Corrections](https://support.crowdin.com/developer/enterprise/api/v2/#tag/String-Corrections/operation/api.projects.corrections.getMany)
- [Add Correction](https://support.crowdin.com/developer/enterprise/api/v2/#tag/String-Corrections/operation/api.projects.corrections.post)
- [Delete Corrections](https://support.crowdin.com/developer/enterprise/api/v2/#tag/String-Corrections/operation/api.projects.corrections.deleteMany)
- [Get Correction](https://support.crowdin.com/developer/enterprise/api/v2/#tag/String-Corrections/operation/api.projects.corrections.get)
- [Restore Correction](https://support.crowdin.com/developer/enterprise/api/v2/#tag/String-Corrections/operation/api.projects.corrections.put)
- [Delete Correction](https://support.crowdin.com/developer/enterprise/api/v2/#tag/String-Corrections/operation/api.projects.corrections.delete)

Closes #230