### PR TITLE
fix: don't use deprecated cast name `(integer)`

### DIFF
--- a/src/CrowdinApiClient/Model/Branch.php
+++ b/src/CrowdinApiClient/Model/Branch.php
@@ -51,8 +51,8 @@ class Branch extends BaseModel
     {
         parent::__construct($data);
 
-        $this->id = (integer)$this->getDataProperty('id');
-        $this->projectId = (integer)$this->getDataProperty('projectId');
+        $this->id = (int)$this->getDataProperty('id');
+        $this->projectId = (int)$this->getDataProperty('projectId');
         $this->name = (string)$this->getDataProperty('name');
         $this->title = (string)$this->getDataProperty('title');
         $this->exportPattern = (string)$this->getDataProperty('exportPattern');

--- a/src/CrowdinApiClient/Model/Bundle.php
+++ b/src/CrowdinApiClient/Model/Bundle.php
@@ -81,7 +81,7 @@ class Bundle extends BaseModel
     {
         parent::__construct($data);
 
-        $this->id = (integer)$this->getDataProperty('id');
+        $this->id = (int)$this->getDataProperty('id');
         $this->name = (string)$this->getDataProperty('name');
         $this->format = (string)$this->getDataProperty('format');
         $this->sourcePatterns = (array)$this->getDataProperty('sourcePatterns');

--- a/src/CrowdinApiClient/Model/BundleExport.php
+++ b/src/CrowdinApiClient/Model/BundleExport.php
@@ -52,7 +52,7 @@ class BundleExport extends BaseModel
         parent::__construct($data);
         $this->identifier = (string)$this->getDataProperty('identifier');
         $this->status = (string)$this->getDataProperty('status');
-        $this->progress = (integer)$this->getDataProperty('progress');
+        $this->progress = (int)$this->getDataProperty('progress');
         $this->attributes = (array)$this->getDataProperty('attributes');
         $this->createdAt = (string)$this->getDataProperty('createdAt');
         $this->updatedAt = (string)$this->getDataProperty('updatedAt');

--- a/src/CrowdinApiClient/Model/Directory.php
+++ b/src/CrowdinApiClient/Model/Directory.php
@@ -61,10 +61,10 @@ class Directory extends BaseModel
     {
         parent::__construct($data);
 
-        $this->id = (integer)$this->getDataProperty('id');
-        $this->projectId = (integer)$this->getDataProperty('projectId');
-        $this->branchId = (integer)$this->getDataProperty('branchId');
-        $this->directoryId = (integer)$this->getDataProperty('directoryId');
+        $this->id = (int)$this->getDataProperty('id');
+        $this->projectId = (int)$this->getDataProperty('projectId');
+        $this->branchId = (int)$this->getDataProperty('branchId');
+        $this->directoryId = (int)$this->getDataProperty('directoryId');
         $this->name = (string)$this->getDataProperty('name');
         $this->title = (string)$this->getDataProperty('title');
         $this->exportPattern = (string)$this->getDataProperty('exportPattern');

--- a/src/CrowdinApiClient/Model/DistributionRelease.php
+++ b/src/CrowdinApiClient/Model/DistributionRelease.php
@@ -39,9 +39,9 @@ class DistributionRelease extends BaseModel
         parent::__construct($data);
 
         $this->status = (string)$this->getDataProperty('status');
-        $this->progress = (integer)$this->getDataProperty('progress');
+        $this->progress = (int)$this->getDataProperty('progress');
         $this->currentLanguageId = (string)$this->getDataProperty('currentLanguageId');
-        $this->currentFileId = (integer)$this->getDataProperty('currentFileId');
+        $this->currentFileId = (int)$this->getDataProperty('currentFileId');
         $this->date = (string)$this->getDataProperty('date');
     }
 

--- a/src/CrowdinApiClient/Model/Enterprise/Group.php
+++ b/src/CrowdinApiClient/Model/Enterprise/Group.php
@@ -63,14 +63,14 @@ class Group extends BaseModel
     {
         parent::__construct($data);
 
-        $this->id = (integer)$this->getDataProperty('id');
+        $this->id = (int)$this->getDataProperty('id');
         $this->name = (string)$this->getDataProperty('name');
         $this->description = (string)$this->getDataProperty('description');
-        $this->parentId = (integer)$this->getDataProperty('parentId');
-        $this->organizationId = (integer)$this->getDataProperty('organizationId');
-        $this->userId = (integer)$this->getDataProperty('userId');
-        $this->subgroupsCount = (integer)$this->getDataProperty('subgroupsCount');
-        $this->projectsCount = (integer)$this->getDataProperty('projectsCount');
+        $this->parentId = (int)$this->getDataProperty('parentId');
+        $this->organizationId = (int)$this->getDataProperty('organizationId');
+        $this->userId = (int)$this->getDataProperty('userId');
+        $this->subgroupsCount = (int)$this->getDataProperty('subgroupsCount');
+        $this->projectsCount = (int)$this->getDataProperty('projectsCount');
         $this->createdAt = (string)$this->getDataProperty('createdAt');
         $this->updatedAt = (string)$this->getDataProperty('updatedAt');
     }

--- a/src/CrowdinApiClient/Model/Enterprise/ReviewedSourceFileBuild.php
+++ b/src/CrowdinApiClient/Model/Enterprise/ReviewedSourceFileBuild.php
@@ -40,10 +40,10 @@ class ReviewedSourceFileBuild extends BaseModel
     {
         parent::__construct($data);
 
-        $this->id = (integer)$this->getDataProperty('id');
-        $this->projectId = (integer)$this->getDataProperty('projectId');
+        $this->id = (int)$this->getDataProperty('id');
+        $this->projectId = (int)$this->getDataProperty('projectId');
         $this->status = (string)$this->getDataProperty('status');
-        $this->progress = (integer)$this->getDataProperty('progress');
+        $this->progress = (int)$this->getDataProperty('progress');
         $this->attributes = (array)$this->getDataProperty('attributes');
     }
 

--- a/src/CrowdinApiClient/Model/Enterprise/User.php
+++ b/src/CrowdinApiClient/Model/Enterprise/User.php
@@ -73,7 +73,7 @@ class User extends BaseModel
     {
         parent::__construct($data);
 
-        $this->id = (integer)$this->getDataProperty('id');
+        $this->id = (int)$this->getDataProperty('id');
         $this->username = (string)$this->getDataProperty('username');
         $this->email = (string)$this->getDataProperty('email');
         $this->firstName = (string)$this->getDataProperty('firstName');

--- a/src/CrowdinApiClient/Model/Enterprise/Vendor.php
+++ b/src/CrowdinApiClient/Model/Enterprise/Vendor.php
@@ -32,7 +32,7 @@ class Vendor extends BaseModel
     public function __construct(array $data = [])
     {
         parent::__construct($data);
-        $this->id = (integer)$this->getDataProperty('id');
+        $this->id = (int)$this->getDataProperty('id');
         $this->name = (string)$this->getDataProperty('name');
         $this->description = (string)$this->getDataProperty('description');
         $this->status = (string)$this->getDataProperty('status');

--- a/src/CrowdinApiClient/Model/Enterprise/WorkflowStep.php
+++ b/src/CrowdinApiClient/Model/Enterprise/WorkflowStep.php
@@ -37,7 +37,7 @@ class WorkflowStep extends BaseModel
     public function __construct(array $data = [])
     {
         parent::__construct($data);
-        $this->id = (integer)$this->getDataProperty('id');
+        $this->id = (int)$this->getDataProperty('id');
         $this->title = (string)$this->getDataProperty('title');
         $this->type = (string)$this->getDataProperty('type');
         $this->languages = (array)$this->getDataProperty('languages');

--- a/src/CrowdinApiClient/Model/Enterprise/WorkflowTemplate.php
+++ b/src/CrowdinApiClient/Model/Enterprise/WorkflowTemplate.php
@@ -77,10 +77,10 @@ class WorkflowTemplate extends BaseModel
     public function __construct(array $data = [])
     {
         parent::__construct($data);
-        $this->id = (integer)$this->getDataProperty('id');
+        $this->id = (int)$this->getDataProperty('id');
         $this->title = (string)$this->getDataProperty('title');
         $this->description = (string)$this->getDataProperty('description');
-        $this->groupId = (integer)$this->getDataProperty('groupId');
+        $this->groupId = (int)$this->getDataProperty('groupId');
         $this->isDefault = (bool)$this->getDataProperty('isDefault');
     }
 }

--- a/src/CrowdinApiClient/Model/File.php
+++ b/src/CrowdinApiClient/Model/File.php
@@ -101,17 +101,17 @@ class File extends BaseModel
     {
         parent::__construct($data);
 
-        $this->id = (integer)$this->getDataProperty('id');
-        $this->projectId = (integer)$this->getDataProperty('projectId');
-        $this->branchId = (integer)$this->getDataProperty('branchId');
-        $this->directoryId = (integer)$this->getDataProperty('directoryId');
+        $this->id = (int)$this->getDataProperty('id');
+        $this->projectId = (int)$this->getDataProperty('projectId');
+        $this->branchId = (int)$this->getDataProperty('branchId');
+        $this->directoryId = (int)$this->getDataProperty('directoryId');
         $this->name = (string)$this->getDataProperty('name');
         $this->title = (string)$this->getDataProperty('title');
         $this->context = (string)$this->getDataProperty('context');
         $this->type = (string)$this->getDataProperty('type');
         $this->path = (string)$this->getDataProperty('path');
         $this->status = (string)$this->getDataProperty('status');
-        $this->revisionId = (integer)$this->getDataProperty('revisionId');
+        $this->revisionId = (int)$this->getDataProperty('revisionId');
         $this->priority = (string)$this->getDataProperty('priority');
         $this->importOptions = (array)$this->getDataProperty('importOptions');
         $this->exportOptions = (array)$this->getDataProperty('exportOptions');

--- a/src/CrowdinApiClient/Model/FileRevision.php
+++ b/src/CrowdinApiClient/Model/FileRevision.php
@@ -44,10 +44,10 @@ class FileRevision extends BaseModel
     public function __construct(array $data = [])
     {
         parent::__construct($data);
-        $this->id = (integer)$this->getDataProperty('id');
-        $this->projectId = (integer)$this->getDataProperty('projectId');
-        $this->restoreToRevision = (integer)$this->getDataProperty('restoreToRevision');
-        $this->fileId = (integer)$this->getDataProperty('fileId');
+        $this->id = (int)$this->getDataProperty('id');
+        $this->projectId = (int)$this->getDataProperty('projectId');
+        $this->restoreToRevision = (int)$this->getDataProperty('restoreToRevision');
+        $this->fileId = (int)$this->getDataProperty('fileId');
         $this->info = (array)$this->getDataProperty('info');
         $this->date = (string)$this->getDataProperty('date');
     }

--- a/src/CrowdinApiClient/Model/Glossary.php
+++ b/src/CrowdinApiClient/Model/Glossary.php
@@ -66,11 +66,11 @@ class Glossary extends BaseModel
     {
         parent::__construct($data);
 
-        $this->id = (integer)$this->getDataProperty('id');
+        $this->id = (int)$this->getDataProperty('id');
         $this->name = (string)$this->getDataProperty('name');
-        $this->groupId = (integer)$this->getDataProperty('groupId');
-        $this->userId = (integer)$this->getDataProperty('userId');
-        $this->terms = (integer)$this->getDataProperty('terms');
+        $this->groupId = (int)$this->getDataProperty('groupId');
+        $this->userId = (int)$this->getDataProperty('userId');
+        $this->terms = (int)$this->getDataProperty('terms');
         $this->languageId = (string)$this->getDataProperty('languageId');
         $this->languageIds = (array)$this->getDataProperty('languageIds');
         $this->defaultProjectIds = (array)$this->getDataProperty('defaultProjectIds');

--- a/src/CrowdinApiClient/Model/GlossaryExport.php
+++ b/src/CrowdinApiClient/Model/GlossaryExport.php
@@ -53,7 +53,7 @@ class GlossaryExport extends BaseModel
 
         $this->identifier = (string)$this->getDataProperty('identifier');
         $this->status = (string)$this->getDataProperty('status');
-        $this->progress = (integer)$this->getDataProperty('progress');
+        $this->progress = (int)$this->getDataProperty('progress');
         $this->attributes = (array)$this->getDataProperty('attributes');
         $this->createdAt = (string)$this->getDataProperty('createdAt');
         $this->updatedAt = (string)$this->getDataProperty('updatedAt');

--- a/src/CrowdinApiClient/Model/GlossaryImport.php
+++ b/src/CrowdinApiClient/Model/GlossaryImport.php
@@ -53,7 +53,7 @@ class GlossaryImport extends BaseModel
 
         $this->identifier = (string)$this->getDataProperty('identifier');
         $this->status = (string)$this->getDataProperty('status');
-        $this->progress = (integer)$this->getDataProperty('progress');
+        $this->progress = (int)$this->getDataProperty('progress');
         $this->attributes = (array)$this->getDataProperty('attributes');
         $this->createdAt = (string)$this->getDataProperty('createdAt');
         $this->updatedAt = (string)$this->getDataProperty('updatedAt');

--- a/src/CrowdinApiClient/Model/Group.php
+++ b/src/CrowdinApiClient/Model/Group.php
@@ -61,14 +61,14 @@ class Group extends BaseModel
     {
         parent::__construct($data);
 
-        $this->id = (integer)$this->getDataProperty('id');
+        $this->id = (int)$this->getDataProperty('id');
         $this->name = (string)$this->getDataProperty('name');
         $this->description = (string)$this->getDataProperty('description');
-        $this->parentId = (integer)$this->getDataProperty('parentId');
-        $this->organizationId = (integer)$this->getDataProperty('organizationId');
-        $this->userId = (integer)$this->getDataProperty('userId');
-        $this->subgroupsCount = (integer)$this->getDataProperty('subgroupsCount');
-        $this->projectsCount = (integer)$this->getDataProperty('projectsCount');
+        $this->parentId = (int)$this->getDataProperty('parentId');
+        $this->organizationId = (int)$this->getDataProperty('organizationId');
+        $this->userId = (int)$this->getDataProperty('userId');
+        $this->subgroupsCount = (int)$this->getDataProperty('subgroupsCount');
+        $this->projectsCount = (int)$this->getDataProperty('projectsCount');
         $this->createdAt = (string)$this->getDataProperty('createdAt');
         $this->updatedAt = (string)$this->getDataProperty('updatedAt');
     }

--- a/src/CrowdinApiClient/Model/Issue.php
+++ b/src/CrowdinApiClient/Model/Issue.php
@@ -60,10 +60,10 @@ class Issue extends BaseModel
     public function __construct(array $data = [])
     {
         parent::__construct($data);
-        $this->id = (integer)$this->getDataProperty('id');
+        $this->id = (int)$this->getDataProperty('id');
         $this->text = (string)$this->getDataProperty('text');
-        $this->userId = (integer)$this->getDataProperty('userId');
-        $this->stringId = (integer)$this->getDataProperty('stringId');
+        $this->userId = (int)$this->getDataProperty('userId');
+        $this->stringId = (int)$this->getDataProperty('stringId');
         $this->user = (array)$this->getDataProperty('user');
         $this->string = (array)$this->getDataProperty('string');
         $this->languageId = (string)$this->getDataProperty('languageId');

--- a/src/CrowdinApiClient/Model/Label.php
+++ b/src/CrowdinApiClient/Model/Label.php
@@ -26,8 +26,8 @@ class Label extends BaseModel
     {
         parent::__construct($data);
 
-        $this->id = (integer)$this->getDataProperty('id');
-        $this->projectId = (integer)$this->getDataProperty('projectId');
+        $this->id = (int)$this->getDataProperty('id');
+        $this->projectId = (int)$this->getDataProperty('projectId');
         $this->title = (string)$this->getDataProperty('title');
     }
 

--- a/src/CrowdinApiClient/Model/MachineTranslationEngine.php
+++ b/src/CrowdinApiClient/Model/MachineTranslationEngine.php
@@ -44,8 +44,8 @@ class MachineTranslationEngine extends BaseModel
     {
         parent::__construct($data);
 
-        $this->id = (integer)$this->getDataProperty('id');
-        $this->groupId = (integer)$this->getDataProperty('groupId');
+        $this->id = (int)$this->getDataProperty('id');
+        $this->groupId = (int)$this->getDataProperty('groupId');
         $this->name = (string)$this->getDataProperty('name');
         $this->type = (string)$this->getDataProperty('type');
         $this->credentials = (array)$this->getDataProperty('credentials');

--- a/src/CrowdinApiClient/Model/PreTranslation.php
+++ b/src/CrowdinApiClient/Model/PreTranslation.php
@@ -53,7 +53,7 @@ class PreTranslation extends BaseModel
 
         $this->identifier = (string)$this->getDataProperty('identifier');
         $this->status = (string)$this->getDataProperty('status');
-        $this->progress = (integer)$this->getDataProperty('progress');
+        $this->progress = (int)$this->getDataProperty('progress');
         $this->attributes = (array)$this->getDataProperty('attributes');
         $this->createdAt = (string)$this->getDataProperty('createdAt');
         $this->updatedAt = (string)$this->getDataProperty('updatedAt');

--- a/src/CrowdinApiClient/Model/Progress.php
+++ b/src/CrowdinApiClient/Model/Progress.php
@@ -48,8 +48,8 @@ class Progress extends BaseModel
         $this->languageId = (string)$this->getDataProperty('languageId');
         $this->words = (array)$this->getDataProperty('words');
         $this->phrases = (array)$this->getDataProperty('phrases');
-        $this->translationProgress = (integer)$this->getDataProperty('translationProgress');
-        $this->approvalProgress = (integer)$this->getDataProperty('approvalProgress');
+        $this->translationProgress = (int)$this->getDataProperty('translationProgress');
+        $this->approvalProgress = (int)$this->getDataProperty('approvalProgress');
     }
 
     public function getLanguage(): Language

--- a/src/CrowdinApiClient/Model/ProgressLanguage.php
+++ b/src/CrowdinApiClient/Model/ProgressLanguage.php
@@ -48,9 +48,9 @@ class ProgressLanguage extends BaseModel
 
         $this->words = (array)$this->getDataProperty('words');
         $this->phrases = (array)$this->getDataProperty('phrases');
-        $this->translationProgress = (integer)$this->getDataProperty('translationProgress');
-        $this->approvalProgress = (integer)$this->getDataProperty('approvalProgress');
-        $this->fileId = (integer)$this->getDataProperty('fileId');
+        $this->translationProgress = (int)$this->getDataProperty('translationProgress');
+        $this->approvalProgress = (int)$this->getDataProperty('approvalProgress');
+        $this->fileId = (int)$this->getDataProperty('fileId');
         $this->etag = (string)$this->getDataProperty('eTag');
     }
 

--- a/src/CrowdinApiClient/Model/Project.php
+++ b/src/CrowdinApiClient/Model/Project.php
@@ -256,9 +256,9 @@ class Project extends BaseModel
     {
         parent::__construct($data);
 
-        $this->id = (integer)$this->getDataProperty('id');
-        $this->groupId = (integer)$this->getDataProperty('groupId');
-        $this->userId = (integer)$this->getDataProperty('userId');
+        $this->id = (int)$this->getDataProperty('id');
+        $this->groupId = (int)$this->getDataProperty('groupId');
+        $this->userId = (int)$this->getDataProperty('userId');
         $this->sourceLanguageId = (string)$this->getDataProperty('sourceLanguageId');
         $this->targetLanguageIds = (array)$this->getDataProperty('targetLanguageIds');
         $this->targetLanguages = (array)$this->getDataProperty('targetLanguages');
@@ -272,18 +272,18 @@ class Project extends BaseModel
         $this->background = (string)$this->getDataProperty('background');
         $this->isExternal = (bool)$this->getDataProperty('isExternal');
         $this->externalType = (string)$this->getDataProperty('externalType');
-        $this->workflowId = (integer)$this->getDataProperty('workflowId');
+        $this->workflowId = (int)$this->getDataProperty('workflowId');
         $this->hasCrowdsourcing = (bool)$this->getDataProperty('hasCrowdsourcing');
         $this->createdAt = (string)$this->getDataProperty('createdAt');
         $this->updatedAt = (string)$this->getDataProperty('updatedAt');
         $this->lastActivity = (string)$this->getDataProperty('lastActivity');
 
-        $this->translateDuplicates = (integer)$this->getDataProperty('translateDuplicates');
+        $this->translateDuplicates = (int)$this->getDataProperty('translateDuplicates');
         $this->isMtAllowed = (bool)$this->getDataProperty('isMtAllowed');
         $this->autoSubstitution = (bool)$this->getDataProperty('autoSubstitution');
         $this->skipUntranslatedStrings = (bool)$this->getDataProperty('skipUntranslatedStrings');
         $this->skipUntranslatedFiles = (bool)$this->getDataProperty('skipUntranslatedFiles');
-        $this->exportWithMinApprovalsCount = (integer)$this->getDataProperty('exportWithMinApprovalsCount');
+        $this->exportWithMinApprovalsCount = (int)$this->getDataProperty('exportWithMinApprovalsCount');
         $this->exportApprovedOnly = (bool)$this->getDataProperty('exportApprovedOnly');
         $this->autoTranslateDialects = (bool)$this->getDataProperty('autoTranslateDialects');
         $this->publicDownloads = (bool)$this->getDataProperty('publicDownloads');
@@ -303,8 +303,8 @@ class Project extends BaseModel
         $this->normalizePlaceholder = (bool)$this->getDataProperty('normalizePlaceholder');
         $this->saveMetaInfoInSource = (bool)$this->getDataProperty('saveMetaInfoInSource');
         $this->notificationSettings = (array)$this->getDataProperty('notificationSettings');
-        $this->defaultTmId = (integer)$this->getDataProperty('defaultTmId');
-        $this->defaultGlossaryId = (integer)$this->getDataProperty('defaultGlossaryId');
+        $this->defaultTmId = (int)$this->getDataProperty('defaultTmId');
+        $this->defaultGlossaryId = (int)$this->getDataProperty('defaultGlossaryId');
     }
 
     /**

--- a/src/CrowdinApiClient/Model/QaCheck.php
+++ b/src/CrowdinApiClient/Model/QaCheck.php
@@ -50,13 +50,13 @@ class QaCheck extends BaseModel
     public function __construct(array $data = [])
     {
         parent::__construct($data);
-        $this->stringId = (integer)$this->getDataProperty('stringId');
+        $this->stringId = (int)$this->getDataProperty('stringId');
         $this->languageId = (string)$this->getDataProperty('languageId');
         $this->category = (string)$this->getDataProperty('category');
         $this->categoryDescription = (string)$this->getDataProperty('categoryDescription');
         $this->validation = (string)$this->getDataProperty('validation');
         $this->validationDescription = (string)$this->getDataProperty('validationDescription');
-        $this->pluralId = (integer)$this->getDataProperty('pluralId');
+        $this->pluralId = (int)$this->getDataProperty('pluralId');
         $this->text = (string)$this->getDataProperty('text');
     }
 

--- a/src/CrowdinApiClient/Model/Report.php
+++ b/src/CrowdinApiClient/Model/Report.php
@@ -115,7 +115,7 @@ class Report extends BaseModel
 
         $this->identifier = (string)$this->getDataProperty('identifier');
         $this->status = (string)$this->getDataProperty('status');
-        $this->progress = (integer)$this->getDataProperty('progress');
+        $this->progress = (int)$this->getDataProperty('progress');
         $this->attributes = (array)$this->getDataProperty('attributes');
         $this->createdAt = (string)$this->getDataProperty('createdAt');
         $this->updatedAt = (string)$this->getDataProperty('updatedAt');

--- a/src/CrowdinApiClient/Model/ReportArchive.php
+++ b/src/CrowdinApiClient/Model/ReportArchive.php
@@ -40,10 +40,10 @@ class ReportArchive extends BaseModel
     public function __construct(array $data = [])
     {
         parent::__construct($data);
-        $this->id = (integer)$this->getDataProperty('id');
+        $this->id = (int)$this->getDataProperty('id');
         $this->scopeType = (string)$this->getDataProperty('scopeType');
-        $this->scopeId = (integer)$this->getDataProperty('scopeId');
-        $this->userId = (integer)$this->getDataProperty('userId');
+        $this->scopeId = (int)$this->getDataProperty('scopeId');
+        $this->userId = (int)$this->getDataProperty('userId');
         $this->name = (string)$this->getDataProperty('name');
         $this->webUrl = (string)$this->getDataProperty('webUrl');
         $this->scheme = (array)$this->getDataProperty('scheme');

--- a/src/CrowdinApiClient/Model/ReportArchiveExport.php
+++ b/src/CrowdinApiClient/Model/ReportArchiveExport.php
@@ -49,7 +49,7 @@ class ReportArchiveExport extends BaseModel
         parent::__construct($data);
         $this->identifier = (string)$this->getDataProperty('identifier');
         $this->status = (string)$this->getDataProperty('status');
-        $this->progress = (integer)$this->getDataProperty('progress');
+        $this->progress = (int)$this->getDataProperty('progress');
         $this->attributes = (array)$this->getDataProperty('attributes');
         $this->createdAt = (string)$this->getDataProperty('createdAt');
         $this->updatedAt = (string)$this->getDataProperty('updatedAt');

--- a/src/CrowdinApiClient/Model/Screenshot.php
+++ b/src/CrowdinApiClient/Model/Screenshot.php
@@ -60,12 +60,12 @@ class Screenshot extends BaseModel
     public function __construct(array $data = [])
     {
         parent::__construct($data);
-        $this->id = (integer)$this->getDataProperty('id');
-        $this->userId = (integer)$this->getDataProperty('userId');
+        $this->id = (int)$this->getDataProperty('id');
+        $this->userId = (int)$this->getDataProperty('userId');
         $this->url = (string)$this->getDataProperty('url');
         $this->name = (string)$this->getDataProperty('name');
         $this->size = (array)$this->getDataProperty('size');
-        $this->tagsCount = (integer)$this->getDataProperty('tagsCount');
+        $this->tagsCount = (int)$this->getDataProperty('tagsCount');
         $this->tags = (array)$this->getDataProperty('tags');
         $this->createdAt = (string)$this->getDataProperty('createdAt');
         $this->updatedAt = (string)$this->getDataProperty('updatedAt');

--- a/src/CrowdinApiClient/Model/SourceString.php
+++ b/src/CrowdinApiClient/Model/SourceString.php
@@ -108,14 +108,14 @@ class SourceString extends BaseModel
     {
         parent::__construct($data);
 
-        $this->id = (integer)$this->getDataProperty('id');
-        $this->projectId = (integer)$this->getDataProperty('projectId');
-        $this->fileId = (integer)$this->getDataProperty('fileId');
+        $this->id = (int)$this->getDataProperty('id');
+        $this->projectId = (int)$this->getDataProperty('projectId');
+        $this->fileId = (int)$this->getDataProperty('fileId');
         $this->branchId = $this->getDataProperty('branchId')
-            ? (integer)$this->getDataProperty('branchId')
+            ? (int)$this->getDataProperty('branchId')
             : null;
         $this->directoryId = $this->getDataProperty('directoryId')
-            ? (integer)$this->getDataProperty('directoryId')
+            ? (int)$this->getDataProperty('directoryId')
             : null;
         $this->identifier = (string)$this->getDataProperty('identifier');
         $this->text = is_array($this->getDataProperty('text'))
@@ -123,9 +123,9 @@ class SourceString extends BaseModel
             : (string)$this->getDataProperty('text');
         $this->type = (string)$this->getDataProperty('type');
         $this->context = (string)$this->getDataProperty('context');
-        $this->maxLength = (integer)$this->getDataProperty('maxLength');
+        $this->maxLength = (int)$this->getDataProperty('maxLength');
         $this->isHidden = (bool)$this->getDataProperty('isHidden');
-        $this->revision = (integer)$this->getDataProperty('revision');
+        $this->revision = (int)$this->getDataProperty('revision');
         $this->hasPlurals = (bool)$this->getDataProperty('hasPlurals');
         $this->isIcu = (bool)$this->getDataProperty('isIcu');
         $this->labelIds = (array)$this->getDataProperty('labelIds');

--- a/src/CrowdinApiClient/Model/Storage.php
+++ b/src/CrowdinApiClient/Model/Storage.php
@@ -20,7 +20,7 @@ class Storage extends BaseModel
     public function __construct(array $data = [])
     {
         parent::__construct($data);
-        $this->id = (integer)$this->getDataProperty('id');
+        $this->id = (int)$this->getDataProperty('id');
         $this->fileName = (string)$this->getDataProperty('fileName');
     }
 

--- a/src/CrowdinApiClient/Model/StringComment.php
+++ b/src/CrowdinApiClient/Model/StringComment.php
@@ -80,17 +80,17 @@ class StringComment extends BaseModel
     public function __construct(array $data = [])
     {
         parent::__construct($data);
-        $this->id = (integer)$this->getDataProperty('id');
+        $this->id = (int)$this->getDataProperty('id');
         $this->text = (string)$this->getDataProperty('text');
-        $this->userId = (integer)$this->getDataProperty('userId');
-        $this->stringId = (integer)$this->getDataProperty('stringId');
+        $this->userId = (int)$this->getDataProperty('userId');
+        $this->stringId = (int)$this->getDataProperty('stringId');
         $this->user = (array)$this->getDataProperty('user');
         $this->string = (array)$this->getDataProperty('string');
         $this->languageId = (string)$this->getDataProperty('languageId');
         $this->type = (string)$this->getDataProperty('type');
         $this->issueType = (string)$this->getDataProperty('issueType');
         $this->issueStatus = (string)$this->getDataProperty('issueStatus');
-        $this->resolverId = (integer)$this->getDataProperty('resolverId');
+        $this->resolverId = (int)$this->getDataProperty('resolverId');
         $this->resolver = (array)$this->getDataProperty('resolver');
         $this->resolvedAt = (string)$this->getDataProperty('resolvedAt');
         $this->createdAt = (string)$this->getDataProperty('createdAt');

--- a/src/CrowdinApiClient/Model/StringCorrection.php
+++ b/src/CrowdinApiClient/Model/StringCorrection.php
@@ -36,7 +36,7 @@ class StringCorrection extends BaseModel
     {
         parent::__construct($data);
 
-        $this->id = (integer)$this->getDataProperty('id');
+        $this->id = (int)$this->getDataProperty('id');
         $this->text = (string)$this->getDataProperty('text');
         $this->pluralCategoryName = (string)$this->getDataProperty('pluralCategoryName');
         $this->user = (array)$this->getDataProperty('user');

--- a/src/CrowdinApiClient/Model/StringTranslation.php
+++ b/src/CrowdinApiClient/Model/StringTranslation.php
@@ -41,11 +41,11 @@ class StringTranslation extends BaseModel
     {
         parent::__construct($data);
 
-        $this->id = (integer)$this->getDataProperty('id');
+        $this->id = (int)$this->getDataProperty('id');
         $this->text = (string)$this->getDataProperty('text');
         $this->pluralCategoryName = (string)$this->getDataProperty('pluralCategoryName');
         $this->user = (array)$this->getDataProperty('user');
-        $this->rating = (integer)$this->getDataProperty('rating');
+        $this->rating = (int)$this->getDataProperty('rating');
     }
 
     /**

--- a/src/CrowdinApiClient/Model/StringTranslationApproval.php
+++ b/src/CrowdinApiClient/Model/StringTranslationApproval.php
@@ -46,12 +46,12 @@ class StringTranslationApproval extends BaseModel
     {
         parent::__construct($data);
 
-        $this->id = (integer)$this->getDataProperty('id');
+        $this->id = (int)$this->getDataProperty('id');
         $this->user = (array)$this->getDataProperty('user');
-        $this->translationId = (integer)$this->getDataProperty('translationId');
-        $this->stringId = (integer)$this->getDataProperty('stringId');
+        $this->translationId = (int)$this->getDataProperty('translationId');
+        $this->stringId = (int)$this->getDataProperty('stringId');
         $this->languageId = (string)$this->getDataProperty('languageId');
-        $this->workflowStepId = (integer)$this->getDataProperty('workflowStepId');
+        $this->workflowStepId = (int)$this->getDataProperty('workflowStepId');
         $this->createdAt = (string)$this->getDataProperty('createdAt');
     }
 

--- a/src/CrowdinApiClient/Model/StringsExporterSetting.php
+++ b/src/CrowdinApiClient/Model/StringsExporterSetting.php
@@ -36,7 +36,7 @@ class StringsExporterSetting extends BaseModel
     {
         parent::__construct($data);
 
-        $this->id = (integer)$this->getDataProperty('id');
+        $this->id = (int)$this->getDataProperty('id');
         $this->format = (string)$this->getDataProperty('format');
         $this->settings = (array)$this->getDataProperty('settings');
         $this->createdAt = (string)$this->getDataProperty('createdAt');

--- a/src/CrowdinApiClient/Model/Tag.php
+++ b/src/CrowdinApiClient/Model/Tag.php
@@ -35,9 +35,9 @@ class Tag extends BaseModel
     public function __construct(array $data = [])
     {
         parent::__construct($data);
-        $this->id = (integer)$this->getDataProperty('id');
-        $this->screenshotId = (integer)$this->getDataProperty('screenshotId');
-        $this->stringId = (integer)$this->getDataProperty('stringId');
+        $this->id = (int)$this->getDataProperty('id');
+        $this->screenshotId = (int)$this->getDataProperty('screenshotId');
+        $this->stringId = (int)$this->getDataProperty('stringId');
         $this->position = (array)$this->getDataProperty('position');
         $this->createdAt = (string)$this->getDataProperty('createdAt');
     }

--- a/src/CrowdinApiClient/Model/Task.php
+++ b/src/CrowdinApiClient/Model/Task.php
@@ -146,9 +146,9 @@ class Task extends BaseModel
     {
         parent::__construct($data);
 
-        $this->id = (integer)$this->getDataProperty('id');
-        $this->projectId = (integer)$this->getDataProperty('projectId');
-        $this->creatorId = (integer)$this->getDataProperty('creatorId');
+        $this->id = (int)$this->getDataProperty('id');
+        $this->projectId = (int)$this->getDataProperty('projectId');
+        $this->creatorId = (int)$this->getDataProperty('creatorId');
         $this->type = (string)$this->getDataProperty('type');
         $this->vendor = $this->getDataProperty('vendor') ? (string)$this->getDataProperty('vendor') : null;
         $this->status = (string)$this->getDataProperty('status');
@@ -163,12 +163,12 @@ class Task extends BaseModel
         $this->description = (string)$this->getDataProperty('description');
         $this->hash = (string)$this->getDataProperty('hash');
         $this->translationUrl = (string)$this->getDataProperty('translationUrl');
-        $this->wordsCount = (integer)$this->getDataProperty('wordsCount');
-        $this->filesCount = (integer)$this->getDataProperty('filesCount');
-        $this->commentsCount = (integer)$this->getDataProperty('commentsCount');
+        $this->wordsCount = (int)$this->getDataProperty('wordsCount');
+        $this->filesCount = (int)$this->getDataProperty('filesCount');
+        $this->commentsCount = (int)$this->getDataProperty('commentsCount');
         $this->deadline = (string)$this->getDataProperty('deadline');
         $this->timeRange = (string)$this->getDataProperty('timeRange');
-        $this->workflowStepId = (integer)$this->getDataProperty('workflowStepId');
+        $this->workflowStepId = (int)$this->getDataProperty('workflowStepId');
         $this->buyUrl = $this->getDataProperty('buyUrl') ? (string)$this->getDataProperty('buyUrl') : null;
         $this->createdAt = (string)$this->getDataProperty('createdAt');
         $this->updatedAt = (string)$this->getDataProperty('updatedAt');

--- a/src/CrowdinApiClient/Model/TaskComment.php
+++ b/src/CrowdinApiClient/Model/TaskComment.php
@@ -46,11 +46,11 @@ class TaskComment extends BaseModel
     {
         parent::__construct($data);
 
-        $this->id = (integer)$this->getDataProperty('id');
-        $this->userId = (integer)$this->getDataProperty('userId');
-        $this->taskId = (integer)$this->getDataProperty('taskId');
+        $this->id = (int)$this->getDataProperty('id');
+        $this->userId = (int)$this->getDataProperty('userId');
+        $this->taskId = (int)$this->getDataProperty('taskId');
         $this->text = (string)$this->getDataProperty('text');
-        $this->timeSpent = $this->getDataProperty('timeSpent') ? (integer)$this->getDataProperty('timeSpent') : null;
+        $this->timeSpent = $this->getDataProperty('timeSpent') ? (int)$this->getDataProperty('timeSpent') : null;
         $this->createdAt = (string)$this->getDataProperty('createdAt');
         $this->updatedAt = (string)$this->getDataProperty('updatedAt');
     }

--- a/src/CrowdinApiClient/Model/TaskSettingsTemplate.php
+++ b/src/CrowdinApiClient/Model/TaskSettingsTemplate.php
@@ -32,7 +32,7 @@ class TaskSettingsTemplate extends BaseModel
     public function __construct(array $data = [])
     {
         parent::__construct($data);
-        $this->id = (integer)$this->getDataProperty('id');
+        $this->id = (int)$this->getDataProperty('id');
         $this->name = (string)$this->getDataProperty('name');
         $this->config = (array)$this->getDataProperty('config');
         $this->createdAt = (string)$this->getDataProperty('createdAt');

--- a/src/CrowdinApiClient/Model/Term.php
+++ b/src/CrowdinApiClient/Model/Term.php
@@ -94,9 +94,9 @@ class Term extends BaseModel
     {
         parent::__construct($data);
 
-        $this->id = (integer)$this->getDataProperty('id');
-        $this->userId = (integer)$this->getDataProperty('userId');
-        $this->glossaryId = (integer)$this->getDataProperty('glossaryId');
+        $this->id = (int)$this->getDataProperty('id');
+        $this->userId = (int)$this->getDataProperty('userId');
+        $this->glossaryId = (int)$this->getDataProperty('glossaryId');
         $this->languageId = (string)$this->getDataProperty('languageId');
         $this->text = (string)$this->getDataProperty('text');
         $this->description = (string)$this->getDataProperty('description');

--- a/src/CrowdinApiClient/Model/TranslationMemoryExport.php
+++ b/src/CrowdinApiClient/Model/TranslationMemoryExport.php
@@ -52,7 +52,7 @@ class TranslationMemoryExport extends BaseModel
         parent::__construct($data);
         $this->identifier = (string)$this->getDataProperty('identifier');
         $this->status = (string)$this->getDataProperty('status');
-        $this->progress = (integer)$this->getDataProperty('progress');
+        $this->progress = (int)$this->getDataProperty('progress');
         $this->attributes = (array)$this->getDataProperty('attributes');
         $this->createdAt = (string)$this->getDataProperty('createdAt');
         $this->updatedAt = (string)$this->getDataProperty('updatedAt');

--- a/src/CrowdinApiClient/Model/TranslationMemoryImport.php
+++ b/src/CrowdinApiClient/Model/TranslationMemoryImport.php
@@ -52,7 +52,7 @@ class TranslationMemoryImport extends BaseModel
         parent::__construct($data);
         $this->identifier = (string)$this->getDataProperty('identifier');
         $this->status = (string)$this->getDataProperty('status');
-        $this->progress = (integer)$this->getDataProperty('progress');
+        $this->progress = (int)$this->getDataProperty('progress');
         $this->attributes = (array)$this->getDataProperty('attributes');
         $this->createdAt = (string)$this->getDataProperty('createdAt');
         $this->updatedAt = (string)$this->getDataProperty('updatedAt');

--- a/src/CrowdinApiClient/Model/TranslationMemorySegment.php
+++ b/src/CrowdinApiClient/Model/TranslationMemorySegment.php
@@ -21,7 +21,7 @@ class TranslationMemorySegment extends BaseModel
     {
         parent::__construct($data);
 
-        $this->id = (integer)$this->getDataProperty('id');
+        $this->id = (int)$this->getDataProperty('id');
         $this->records = array_map(static function (array $record): TranslationMemorySegmentRecord {
             return new TranslationMemorySegmentRecord($record);
         }, (array)$this->getDataProperty('records'));

--- a/src/CrowdinApiClient/Model/TranslationMemorySegmentRecord.php
+++ b/src/CrowdinApiClient/Model/TranslationMemorySegmentRecord.php
@@ -50,12 +50,12 @@ class TranslationMemorySegmentRecord extends BaseModel
     public function __construct(array $data = [])
     {
         parent::__construct($data);
-        $this->id = (integer)$this->getDataProperty('id');
+        $this->id = (int)$this->getDataProperty('id');
         $this->languageId = (string)$this->getDataProperty('languageId');
         $this->text = (string)$this->getDataProperty('text');
-        $this->usageCount = (integer)$this->getDataProperty('usageCount');
-        $this->createdBy = (integer)$this->getDataProperty('createdBy');
-        $this->updatedBy = (integer)$this->getDataProperty('updatedBy');
+        $this->usageCount = (int)$this->getDataProperty('usageCount');
+        $this->createdBy = (int)$this->getDataProperty('createdBy');
+        $this->updatedBy = (int)$this->getDataProperty('updatedBy');
         $this->createdAt = (string)$this->getDataProperty('createdAt');
         $this->updatedAt = (string)$this->getDataProperty('updatedAt');
     }

--- a/src/CrowdinApiClient/Model/TranslationProjectBuild.php
+++ b/src/CrowdinApiClient/Model/TranslationProjectBuild.php
@@ -36,10 +36,10 @@ class TranslationProjectBuild extends BaseModel
     {
         parent::__construct($data);
 
-        $this->id = (integer)$this->getDataProperty('id');
-        $this->projectId = (integer)$this->getDataProperty('projectId');
+        $this->id = (int)$this->getDataProperty('id');
+        $this->projectId = (int)$this->getDataProperty('projectId');
         $this->status = (string)$this->getDataProperty('status');
-        $this->progress = (integer)$this->getDataProperty('progress');
+        $this->progress = (int)$this->getDataProperty('progress');
         $this->attributes = (array)$this->getDataProperty('attributes');
     }
 

--- a/src/CrowdinApiClient/Model/TranslationProjectDirectory.php
+++ b/src/CrowdinApiClient/Model/TranslationProjectDirectory.php
@@ -43,10 +43,10 @@ class TranslationProjectDirectory extends BaseModel
     {
         parent::__construct($data);
 
-        $this->id = (integer)$this->getDataProperty('id');
-        $this->projectId = (integer)$this->getDataProperty('projectId');
+        $this->id = (int)$this->getDataProperty('id');
+        $this->projectId = (int)$this->getDataProperty('projectId');
         $this->status = (string)$this->getDataProperty('status');
-        $this->progress = (integer)$this->getDataProperty('progress');
+        $this->progress = (int)$this->getDataProperty('progress');
         $this->createdAt = (string)$this->getDataProperty('createdAt');
         $this->updatedAt = (string)$this->getDataProperty('updatedAt');
         $this->finishedAt = (string)$this->getDataProperty('finishedAt');

--- a/src/CrowdinApiClient/Model/User.php
+++ b/src/CrowdinApiClient/Model/User.php
@@ -56,7 +56,7 @@ class User extends BaseModel
     {
         parent::__construct($data);
 
-        $this->id = (integer)$this->getDataProperty('id');
+        $this->id = (int)$this->getDataProperty('id');
         $this->username = (string)$this->getDataProperty('username');
         $this->email = (string)$this->getDataProperty('email');
         $this->fullName = (string)$this->getDataProperty('fullName');


### PR DESCRIPTION
The `(integer)` cast name has been deprecated in PHP 8.5, `(int)` should be used instead. 